### PR TITLE
Add AI Credits report support, latest metrics fields, and dashboard UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ The dashboard now handles both:
 * **User-level records** (for per-user analysis, user flags, and CSV export)
 * **Aggregate day totals** from enterprise/org reports (including `day_totals`, CLI metrics, pull request activity, and monthly/daily active user fields)
 
+It is aligned to the latest usage-metrics schema, including per-user **AI adoption phase** (`ai_adoption_phase`), **Copilot cloud agent** (`used_copilot_cloud_agent`), and **Copilot coding agent** (`used_copilot_coding_agent`) signals.
+
+It also supports an optional **AI Credits usage report (CSV)** upload — the premium-request / AI-credit billing export — which adds a dedicated **"AI Credits & cost"** dashboard section and merges credit spend into the per-user table. All credit views respect the same date, user-search, and members-only filters. 1 AI credit = $0.01.
+
 ### Quick Start Options
 
 #### Option 1: Upload + (Optional) API Members Fetch (Recommended Hybrid)
@@ -103,7 +107,7 @@ Screenshots:
 Summary cards now reflect the latest Copilot usage metrics reference, including active-user rollups, chat usage, LoC changed with AI, agent contribution, CLI usage, code review activity, and pull request totals when present in the export.
 
 Below them, the dashboard renders updated chart groups for:
-* Adoption, usage, and chat modes
+* Adoption, usage, and chat modes (including **AI adoption phase distribution**)
 * Model usage (overall, per day, per chat mode, per language)
 * Language usage (overall and per day)
 * IDE distribution
@@ -111,10 +115,21 @@ Below them, the dashboard renders updated chart groups for:
 * Code generation views: LoC suggested vs changed, daily added/deleted lines, and user-initiated vs agent-initiated changes
 * Pull request and Copilot review suggestion activity
 
+When they are present in the export, the summary cards also surface **Coding Agent Users**, **Cloud Agent Users**, and the **Top Adoption Phase**.
+
+#### AI Credits & cost (optional)
+Upload the **AI Credits usage report** CSV in the controls (the "AI Credits usage report" file picker) to unlock a dedicated **AI Credits & cost** section. It shows:
+* Cards for total AI credits, net/gross cost, discounts, users with spend, average credits per user, most expensive model, per-user monthly quota, and overage (when present).
+* Charts for credits by model, credits and net cost per day, top users by credits, credits by organization / cost center, and auto- vs manually-selected model credits.
+* Tables for credits by model, user, organization, and cost center.
+
+The report can be loaded on its own (cost-only) or alongside a metrics export. When both are loaded, credit spend is merged into the per-user table (see below). The CSV must include at least `date`, `model`, `quantity`, `net_amount`, and `unit_type` columns; models prefixed with `Auto:` are treated as auto-selected.
+
 #### Reference tables
 The **Reference tables** section mirrors the newer schema with sortable-by-filter tables for:
 * Daily overview values
 * Feature, language, model, and IDE breakdowns
+* AI adoption phases
 * CLI activity
 * Code review activity
 * Pull request lifecycle activity
@@ -123,8 +138,10 @@ The **Reference tables** section mirrors the newer schema with sortable-by-filte
 Click the **User Usage Table** button (enabled when user-level records are present) to view a sortable table of aggregated metrics per user. It now includes:
 * Interactions, completions, acceptances, acceptance %
 * Active days, chat days, agent days, CLI days, and code review days
+* Adoption phase, cloud agent days, and coding agent days (when those fields are present)
 * CLI requests / sessions
 * LoC Suggested (add/delete), LoC Added, LoC Deleted
+* **AI Credits** and **AI Credit Cost** per user (when an AI Credits report is loaded)
 * Top model, language, feature, IDE, and chat mode
 
 You can:
@@ -137,7 +154,7 @@ Hover any chart element for tooltips. Categories auto‑trim if extremely long t
 
 ### 6. Generate a PDF report
 1. (Optional) Enter Enterprise Name and/or Organization Name (for labeling only; not used for API fetch now).
-2. Click “Download PDF” after data loads. A multi‑page PDF (summary grid + each chart) is generated entirely in your browser.
+2. Click “Download PDF” after data loads. A multi‑page PDF (summary grid + each chart) is generated entirely in your browser. When an AI Credits report is loaded, the credit cost cards and charts are included too.
 3. Reference tables and the per-user CSV export are kept in the web view; they are not embedded in the PDF.
 
 ### 7. Privacy & local‑only behavior
@@ -153,7 +170,10 @@ Hover any chart element for tooltips. Categories auto‑trim if extremely long t
 | LoC values are null | Before 2025-09-01 exports may include legacy fields where new LoC metrics are null. Update IDEs and use newer dates for full LoC coverage. |
 | Members only disabled | Upload a members file with objects containing a login field. |
 | Date inputs empty or disabled | Ensure records or `day_totals` entries contain a `day` field (YYYY-MM-DD). |
-| PDF button disabled | Load a metrics file first; button enables after successful parsing. |
+| PDF button disabled | Load a metrics file (or an AI Credits report) first; button enables after successful parsing. |
+| AI Credits section not showing | Upload the AI Credits usage report via the "AI Credits usage report" file picker. The CSV must include `date`, `model`, `quantity`, `net_amount`, and `unit_type` columns. |
+| "Missing expected column(s)" on AI Credits upload | The file isn't the AI Credits usage report, or its header row was altered. Re-export the premium-request / AI-credit usage CSV and upload it unmodified. |
+| AI Credit columns missing from per-user table | Load both a metrics export and an AI Credits report; credits merge onto users by matching `username` to the login (case-insensitive). Rows without a username stay in totals but not per-user. |
 
 ### 9. Suggested workflow
 1. Download latest enterprise metrics export from GitHub.
@@ -163,7 +183,8 @@ Hover any chart element for tooltips. Categories auto‑trim if extremely long t
 5. Review acceptance, agent adoption %, active-user rollups, and most used chat model.
 6. Review LoC metrics: suggested vs changed, user-initiated vs agent-initiated edits, and language/model breakdowns.
 7. If present in the export, review CLI activity, code review activity, and pull request metrics.
-8. Export PDF for charts or CSV for per-user detail.
+8. (Optional) Upload the AI Credits usage report CSV to review credit spend and cost, and to see per-user cost in the user table.
+9. Export PDF for charts or CSV for per-user detail.
 
 ### 10. FAQ
 * Does it send data over the network? \

--- a/index.html
+++ b/index.html
@@ -62,6 +62,15 @@
                                 <input type="file" id="jsonFileInput" class="visually-hidden-file" accept=".json,.jsonl,.ndjson,.txt,application/json" aria-describedby="metricsFileHelp" required />
                                 <div id="metricsFileHelp" class="assist-text">JSON or JSON Lines export.</div>
                             </div>
+                            <div class="control-item file-picker toolbar-item toolbar-item-wide" id="aiCreditsFileWrap">
+                                <label for="aiCreditsFileInput">AI Credits usage report <span class="optional">(optional)</span></label>
+                                <div class="upload-inline">
+                                    <button type="button" id="aiCreditsFileTrigger" class="file-upload-trigger">Choose file</button>
+                                    <span id="aiCreditsFileName" class="file-upload-name">No file chosen</span>
+                                </div>
+                                <input type="file" id="aiCreditsFileInput" class="visually-hidden-file" accept=".csv,text/csv" aria-describedby="aiCreditsFileHelp" />
+                                <div id="aiCreditsFileHelp" class="assist-text">CSV export of premium request / AI credit usage. Adds a cost dashboard and per-user spend.</div>
+                            </div>
                             <details class="advanced-filters" id="advancedFilters">
                                 <summary><span class="summary-label">Date range</span></summary>
                                 <div class="adv-content">
@@ -183,6 +192,19 @@
             <div id="chartsContainer" class="charts-grid" aria-live="polite"></div>
         </section>
 
+        <section id="creditsSection" class="panel charts-panel" role="region" aria-labelledby="creditsHeading" tabindex="-1" hidden>
+            <div class="section-heading section-heading-compact">
+                <div>
+                    <p class="section-kicker">Cost</p>
+                    <h2 id="creditsHeading" class="panel-title">AI Credits &amp; cost</h2>
+                    <p class="panel-intro">Premium request / AI credit spend from the uploaded usage report, filtered by the same date, user, and members-only controls. 1 AI credit = $0.01.</p>
+                </div>
+            </div>
+            <div id="creditsMetrics" class="metrics-grid" aria-live="polite"></div>
+            <div id="creditsCharts" class="charts-grid" aria-live="polite"></div>
+            <div id="creditsTables" class="table-blocks" aria-live="polite"></div>
+        </section>
+
         <section id="tablesSection" class="panel tables-panel" role="region" aria-labelledby="tablesHeading" hidden>
             <div class="section-heading section-heading-compact">
                 <div>
@@ -221,7 +243,7 @@
     </div>
 
     <footer class="app-footer small-note">
-        <span>Aligned to the current GitHub Copilot usage metrics schema. Everything is processed locally in your browser.</span>
+        <span>Aligned to the current GitHub Copilot usage metrics schema, including AI adoption phase, cloud/coding agent usage, and optional AI Credits cost reporting. Everything is processed locally in your browser.</span>
     </footer>
 
     <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     </script>
     <title>GitHub Copilot Metrics Analyzer</title>
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='%23f5f8fd'/%3E%3Cpath d='M8 22h4V14H8zm6 0h4V10h-4zm6 0h4V17h-4z' fill='%230b5bd3'/%3E%3C/svg%3E" />
-    <link rel="stylesheet" href="style.css?v=20260709-3" />
+    <link rel="stylesheet" href="style.css?v=20260709-4" />
 </head>
 <body>
     <a class="skip-link" href="#mainContent">Skip to dashboard content</a>
@@ -123,6 +123,7 @@
                                 <button type="button" id="resetFiltersBtn" class="secondary">Reset</button>
                                 <button type="button" id="downloadPdfBtn" class="secondary" disabled aria-label="Download dashboard as PDF">Download PDF</button>
                                 <button type="button" id="userUsageBtn" class="secondary" disabled aria-label="View per-user detail table">User table</button>
+                                <button type="button" id="clearDataBtn" class="secondary danger-action" disabled aria-label="Clear all loaded data and reset the dashboard">Clear</button>
                             </div>
                             <div class="side-details">
                                 <details class="compact-details" id="membersOptions">
@@ -272,6 +273,6 @@
     <!-- Libraries for enhanced PDF export -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" integrity="sha512-BNaRQnYJYiPSqHHDb58B0yaPfCu+Wgds8Gp/gU33kqBtgNS4tSPHuGibyoeqMV/TJlSKda6FXzoEyYGjTe+vXA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/3.0.2/jspdf.umd.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="script.js?v=20260709-3"></script>
+    <script src="script.js?v=20260709-4"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     </script>
     <title>GitHub Copilot Metrics Analyzer</title>
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='%23f5f8fd'/%3E%3Cpath d='M8 22h4V14H8zm6 0h4V10h-4zm6 0h4V17h-4z' fill='%230b5bd3'/%3E%3C/svg%3E" />
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style.css?v=20260709-2" />
 </head>
 <body>
     <a class="skip-link" href="#mainContent">Skip to dashboard content</a>
@@ -254,6 +254,6 @@
     <!-- Libraries for enhanced PDF export -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" integrity="sha512-BNaRQnYJYiPSqHHDb58B0yaPfCu+Wgds8Gp/gU33kqBtgNS4tSPHuGibyoeqMV/TJlSKda6FXzoEyYGjTe+vXA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/3.0.2/jspdf.umd.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="script.js"></script>
+    <script src="script.js?v=20260709-2"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     </script>
     <title>GitHub Copilot Metrics Analyzer</title>
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='%23f5f8fd'/%3E%3Cpath d='M8 22h4V14H8zm6 0h4V10h-4zm6 0h4V17h-4z' fill='%230b5bd3'/%3E%3C/svg%3E" />
-    <link rel="stylesheet" href="style.css?v=20260709-2" />
+    <link rel="stylesheet" href="style.css?v=20260709-3" />
 </head>
 <body>
     <a class="skip-link" href="#mainContent">Skip to dashboard content</a>
@@ -40,7 +40,18 @@
         </nav>
     </header>
     <main id="mainContent" tabindex="-1">
-        <section class="panel controls-panel" role="region" aria-labelledby="controlsHeading">
+        <nav class="section-nav" aria-label="Jump to section">
+            <span class="section-nav-label" aria-hidden="true">Jump to</span>
+            <ul class="section-nav-list">
+                <li><a href="#controlsSection">Load &amp; filter</a></li>
+                <li><a href="#summarySection">Key metrics</a></li>
+                <li data-section-link="chartsSection"><a href="#chartsSection">Charts</a></li>
+                <li data-section-link="creditsSection" hidden><a href="#creditsSection">AI Credits</a></li>
+                <li data-section-link="tablesSection" hidden><a href="#tablesSection">Reference tables</a></li>
+                <li data-section-link="userUsageSection" hidden><a href="#userUsageSection">Per-user detail</a></li>
+            </ul>
+        </nav>
+        <section id="controlsSection" class="panel controls-panel" role="region" aria-labelledby="controlsHeading">
             <div class="section-heading section-heading-compact controls-heading">
                 <div class="heading-copy">
                     <h2 id="controlsHeading" class="panel-title">Load metrics and filter the view</h2>
@@ -170,7 +181,7 @@
             <div id="statusMessage" class="status" role="status" aria-live="polite" aria-atomic="true" tabindex="-1"></div>
         </section>
 
-        <section class="panel metrics-panel" role="region" aria-labelledby="summaryHeading">
+        <section id="summarySection" class="panel metrics-panel" role="region" aria-labelledby="summaryHeading">
             <div class="section-heading section-heading-compact">
                 <div>
                     <p class="section-kicker">Overview</p>
@@ -246,6 +257,13 @@
         <span>Aligned to the current GitHub Copilot usage metrics schema, including AI adoption phase, cloud/coding agent usage, and optional AI Credits cost reporting. Everything is processed locally in your browser.</span>
     </footer>
 
+    <button type="button" id="backToTopBtn" class="back-to-top" aria-label="Back to top" title="Back to top">
+        <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+            <path d="M12 19V5" />
+            <path d="M5 12l7-7 7 7" />
+        </svg>
+    </button>
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highcharts/11.4.8/highcharts.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highcharts/11.4.8/modules/exporting.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highcharts/11.4.8/modules/export-data.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
@@ -254,6 +272,6 @@
     <!-- Libraries for enhanced PDF export -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" integrity="sha512-BNaRQnYJYiPSqHHDb58B0yaPfCu+Wgds8Gp/gU33kqBtgNS4tSPHuGibyoeqMV/TJlSKda6FXzoEyYGjTe+vXA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/3.0.2/jspdf.umd.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="script.js?v=20260709-2"></script>
+    <script src="script.js?v=20260709-3"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -246,11 +246,11 @@
         <span>Aligned to the current GitHub Copilot usage metrics schema, including AI adoption phase, cloud/coding agent usage, and optional AI Credits cost reporting. Everything is processed locally in your browser.</span>
     </footer>
 
-    <script src="https://code.highcharts.com/highcharts.js"></script>
-    <script src="https://code.highcharts.com/modules/exporting.js"></script>
-    <script src="https://code.highcharts.com/modules/export-data.js"></script>
-    <script src="https://code.highcharts.com/modules/heatmap.js"></script>
-    <script src="https://code.highcharts.com/modules/accessibility.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highcharts/11.4.8/highcharts.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highcharts/11.4.8/modules/exporting.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highcharts/11.4.8/modules/export-data.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highcharts/11.4.8/modules/heatmap.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highcharts/11.4.8/modules/accessibility.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <!-- Libraries for enhanced PDF export -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" integrity="sha512-BNaRQnYJYiPSqHHDb58B0yaPfCu+Wgds8Gp/gU33kqBtgNS4tSPHuGibyoeqMV/TJlSKda6FXzoEyYGjTe+vXA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/3.0.2/jspdf.umd.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/script.js
+++ b/script.js
@@ -254,7 +254,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const downloadBtn = document.getElementById('downloadPdfBtn');
     if (downloadBtn) {
         downloadBtn.addEventListener('click', () => {
-            if (!window.__rawData || !window.__rawData.length) return;
+            const hasMetrics = window.__rawData && window.__rawData.length;
+            const hasCredits = window.__aiCreditsRaw && window.__aiCreditsRaw.length;
+            if (!hasMetrics && !hasCredits) return;
             generatePdfReport();
         });
     }
@@ -268,6 +270,20 @@ document.addEventListener('DOMContentLoaded', () => {
     const membersInputEl = document.getElementById('membersFileInput');
     if (membersInputEl) {
         membersInputEl.addEventListener('change', () => membersInputEl.files && handleMembersFile(membersInputEl.files[0]));
+    }
+
+    // AI Credits (premium request) CSV upload
+    const aiCreditsInputEl = document.getElementById('aiCreditsFileInput');
+    const aiCreditsTriggerEl = document.getElementById('aiCreditsFileTrigger');
+    if (aiCreditsTriggerEl && aiCreditsInputEl) {
+        aiCreditsTriggerEl.addEventListener('click', () => aiCreditsInputEl.click());
+    }
+    if (aiCreditsInputEl) {
+        syncSelectedFileName(aiCreditsInputEl, 'aiCreditsFileName');
+        aiCreditsInputEl.addEventListener('change', () => {
+            syncSelectedFileName(aiCreditsInputEl, 'aiCreditsFileName');
+            if (aiCreditsInputEl.files && aiCreditsInputEl.files[0]) handleAiCreditsFile(aiCreditsInputEl.files[0]);
+        });
     }
 
     // Per-user usage view navigation & export
@@ -299,6 +315,7 @@ function syncSelectedFileName(inputEl, outputId, emptyText = 'No file chosen') {
 function looksLikeUsageRecordObject(obj) {
     if (!obj || typeof obj !== 'object') return false;
     return [
+        'ai_adoption_phase',
         'day',
         'day_totals',
         'enterprise_id',
@@ -309,6 +326,8 @@ function looksLikeUsageRecordObject(obj) {
         'totals_by_cli',
         'totals_by_feature',
         'totals_by_ide',
+        'used_copilot_cloud_agent',
+        'used_copilot_coding_agent',
         'user_id',
         'user_login'
     ].some(key => Object.prototype.hasOwnProperty.call(obj, key));
@@ -548,10 +567,13 @@ function analyzeData(data) {
 
     if (!data || data.length === 0) {
         const hasLoadedData = Boolean(window.__rawData && window.__rawData.length);
+        const hasCredits = Boolean(window.__aiCreditsRaw && window.__aiCreditsRaw.length);
         setStatus(
             hasLoadedData
                 ? 'No records match the current filters. Widen the date range, clear user search, or turn off the members-only filter.'
-                : 'Ready for a metrics export. Upload a JSON or JSON Lines file to populate the dashboard.'
+                : (hasCredits
+                    ? 'AI Credits report loaded. Upload a usage-metrics JSON/JSONL file to combine credit cost with engagement metrics.'
+                    : 'Ready for a metrics export. Upload a JSON or JSON Lines file to populate the dashboard.')
         );
         const tablesSection = document.getElementById('tablesSection');
         if (tablesSection) tablesSection.hidden = true;
@@ -560,6 +582,7 @@ function analyzeData(data) {
         if (downloadBtn) downloadBtn.disabled = true;
         const userUsageBtn = document.getElementById('userUsageBtn');
         if (userUsageBtn) userUsageBtn.disabled = true;
+        updateCreditsView();
         return;
     }
 
@@ -570,6 +593,7 @@ function analyzeData(data) {
     computeSummaryMetrics(model);
     renderCharts(model);
     renderReferenceTables(model);
+    updateCreditsView();
     enableDownloadButton();
 
     const userUsageBtn = document.getElementById('userUsageBtn');
@@ -616,8 +640,11 @@ function buildDashboardModel(data) {
     const chatUsers = new Set();
     const agentUsers = new Set();
     const cliUsers = new Set();
+    const cloudAgentUsers = new Set();
+    const codingAgentUsers = new Set();
     const reviewActiveUsers = new Set();
     const reviewPassiveUsers = new Set();
+    const userAdoptionPhase = new Map();
 
     let totalInteractions = 0;
     let totalGenerations = 0;
@@ -625,6 +652,8 @@ function buildDashboardModel(data) {
     let hasCli = false;
     let hasPullRequests = false;
     let hasCodeReview = false;
+    let hasCloudAgent = false;
+    let hasCodingAgent = false;
 
     overallRecords.forEach(record => {
         const day = record.day || '';
@@ -737,6 +766,25 @@ function buildDashboardModel(data) {
             getOrCreateMapValue(dayReviewPassiveSets, day, () => new Set()).add(userKey);
             hasCodeReview = true;
         }
+        if (record.used_copilot_cloud_agent) {
+            cloudAgentUsers.add(userKey);
+            hasCloudAgent = true;
+        }
+        if (record.used_copilot_coding_agent) {
+            codingAgentUsers.add(userKey);
+            hasCodingAgent = true;
+        }
+        if (record.ai_adoption_phase && typeof record.ai_adoption_phase === 'object') {
+            const existing = userAdoptionPhase.get(userKey);
+            if (!existing || day >= existing.day) {
+                userAdoptionPhase.set(userKey, {
+                    phase: record.ai_adoption_phase.phase || 'Unknown',
+                    phase_number: toNum(record.ai_adoption_phase.phase_number),
+                    version: record.ai_adoption_phase.version || '',
+                    day
+                });
+            }
+        }
     });
 
     const daySet = new Set([
@@ -777,6 +825,23 @@ function buildDashboardModel(data) {
             active_users: row.code_review_active_users,
             passive_users: row.code_review_passive_users
         }));
+
+    const adoptionPhaseMap = new Map();
+    userAdoptionPhase.forEach(info => {
+        const key = info.phase || 'Unknown';
+        const row = getOrCreateMapValue(adoptionPhaseMap, key, () => ({
+            phase: key,
+            phase_number: info.phase_number,
+            users: 0
+        }));
+        row.users += 1;
+        row.phase_number = info.phase_number;
+    });
+    const adoptionPhaseRows = Array.from(adoptionPhaseMap.values())
+        .sort((a, b) => (a.phase_number - b.phase_number) || a.phase.localeCompare(b.phase));
+    const topAdoptionPhase = adoptionPhaseRows.length
+        ? [...adoptionPhaseRows].sort((a, b) => b.users - a.users)[0].phase
+        : 'n/a';
 
     const latestDailyRow = dailyRows[dailyRows.length - 1] || createDailyOverviewRow('');
     const latestDailyActiveUsers = toNum(latestDailyRow.daily_active_users);
@@ -840,6 +905,9 @@ function buildDashboardModel(data) {
             hasCli,
             hasPullRequests,
             hasCodeReview,
+            hasCloudAgent,
+            hasCodingAgent,
+            hasAdoptionPhase: adoptionPhaseRows.length > 0,
             days,
             latestDay: days[days.length - 1] || '',
             earliestDay: days[0] || ''
@@ -867,6 +935,9 @@ function buildDashboardModel(data) {
             cliUsers: cliUsers.size,
             reviewActiveUsers: reviewActiveUsers.size,
             reviewPassiveUsers: reviewPassiveUsers.size,
+            cloudAgentUsers: cloudAgentUsers.size,
+            codingAgentUsers: codingAgentUsers.size,
+            topAdoptionPhase,
             pullRequests: pullRequestTotals,
             cli: cliTotals
         },
@@ -879,7 +950,8 @@ function buildDashboardModel(data) {
             modelRows,
             cliDayRows,
             pullRequestDayRows,
-            codeReviewDayRows
+            codeReviewDayRows,
+            adoptionPhaseRows
         },
         matrices: {
             dayLanguageMap,
@@ -963,6 +1035,15 @@ function renderCharts(model) {
 
     if (model.breakdowns.weeklyRows.length) {
         createChart('Weekly Active Users', 'line', model.breakdowns.weeklyRows.map(row => row.label), model.breakdowns.weeklyRows.map(row => row.value));
+    }
+
+    if (model.breakdowns.adoptionPhaseRows && model.breakdowns.adoptionPhaseRows.length) {
+        createChart(
+            'AI Adoption Phase Distribution',
+            'doughnut',
+            model.breakdowns.adoptionPhaseRows.map(row => row.phase),
+            model.breakdowns.adoptionPhaseRows.map(row => row.users)
+        );
     }
 
     if (model.userRows.length) {
@@ -1198,6 +1279,25 @@ function renderReferenceTables(model) {
                 { key: 'latest_plugin_version', label: 'Latest plugin version' }
             ],
             model.breakdowns.ideRows
+        ));
+    }
+
+    if (model.breakdowns.adoptionPhaseRows && model.breakdowns.adoptionPhaseRows.length) {
+        const totalPhaseUsers = model.breakdowns.adoptionPhaseRows.reduce((acc, row) => acc + toNum(row.users), 0);
+        const phaseRows = model.breakdowns.adoptionPhaseRows.map(row => ({
+            ...row,
+            share: totalPhaseUsers ? (row.users / totalPhaseUsers) * 100 : 0
+        }));
+        blocks.push(renderTableBlock(
+            'AI adoption phases',
+            'Distribution of users across AI adoption phases (each user counted once, using their most recent phase in range).',
+            [
+                { key: 'phase', label: 'Phase' },
+                { key: 'phase_number', label: 'Phase #', type: 'number' },
+                { key: 'users', label: 'Users', type: 'number' },
+                { key: 'share', label: 'Share %', type: 'decimal' }
+            ],
+            phaseRows
         ));
     }
 
@@ -1541,8 +1641,8 @@ function sumNestedMap(map) {
     return total;
 }
 
-function createChart(title, type, categories, seriesData) {
-    const chartsContainer = document.getElementById('chartsContainer');
+function createChart(title, type, categories, seriesData, container) {
+    const chartsContainer = container || document.getElementById('chartsContainer');
     const chartContainer = document.createElement('div');
     chartContainer.classList.add('chart-container');
     chartContainer.setAttribute('role','group');
@@ -1590,8 +1690,8 @@ function createChart(title, type, categories, seriesData) {
     Highcharts.chart(div, buildOptions(categories, seriesData));
 }
 
-function createGroupedBarChart(title, categories, datasets) {
-    const chartsContainer = document.getElementById('chartsContainer');
+function createGroupedBarChart(title, categories, datasets, container) {
+    const chartsContainer = container || document.getElementById('chartsContainer');
     const chartContainer = document.createElement('div');
     chartContainer.classList.add('chart-container');
     chartContainer.setAttribute('role', 'group');
@@ -1657,8 +1757,8 @@ function createHeatmap(title, xCategories, yCategories, dataPoints, colorAxisTit
     });
 }
 
-function createStackedChart(title, categories, series, type='column', stacking='normal') {
-    const chartsContainer = document.getElementById('chartsContainer');
+function createStackedChart(title, categories, series, type='column', stacking='normal', container) {
+    const chartsContainer = container || document.getElementById('chartsContainer');
     const chartContainer = document.createElement('div');
     chartContainer.classList.add('chart-container');
     chartContainer.setAttribute('role','group');
@@ -1707,8 +1807,9 @@ function initializeFilters(data) {
     // Reset text search
     const searchEl = document.getElementById('userSearch');
     if (searchEl) searchEl.value = '';
-    // Reset date range to full span
-    if (days.length) { dateFrom.value = days[0]; dateTo.value = days[days.length - 1]; }
+    // Reset date range to the full span (union of metric days and any credit dates)
+    const allDays = (window.__allDays && window.__allDays.length) ? window.__allDays : days;
+    if (allDays.length) { dateFrom.value = allDays[0]; dateTo.value = allDays[allDays.length - 1]; }
     // Reset members-only filter
     const membersChk = document.getElementById('membersOnlyChk');
     if (membersChk) membersChk.checked = false;
@@ -1729,6 +1830,9 @@ function initializeFilters(data) {
 
     enableApplyButton();
     setupQuickRangeButtons();
+    // If an AI Credits report is already loaded, widen the bounds to the union
+    // so credit dates outside the metrics window remain visible.
+    if (window.__aiCreditsRaw && window.__aiCreditsRaw.length) refreshDateBoundsUnion();
     // Cache initial dataset for user usage table reuse
     window.__currentFilteredData = data;
 }
@@ -1844,6 +1948,19 @@ function computeSummaryMetrics(model) {
             { label: 'Code Review Active Users', value: model.totals.reviewActiveUsers.toLocaleString() },
             { label: 'Code Review Passive Users', value: model.totals.reviewPassiveUsers.toLocaleString() }
         );
+    }
+
+    if (model.meta.hasCloudAgent || model.meta.hasCodingAgent) {
+        if (model.meta.hasCodingAgent) {
+            cards.push({ label: 'Coding Agent Users', value: model.totals.codingAgentUsers.toLocaleString() });
+        }
+        if (model.meta.hasCloudAgent) {
+            cards.push({ label: 'Cloud Agent Users', value: model.totals.cloudAgentUsers.toLocaleString() });
+        }
+    }
+
+    if (model.meta.hasAdoptionPhase) {
+        cards.push({ label: 'Top Adoption Phase', value: model.totals.topAdoptionPhase });
     }
 
     if (model.meta.hasPullRequests) {
@@ -2126,8 +2243,8 @@ async function generatePdfReport() {
     if (enterpriseName && !headerTitle.includes(enterpriseName)) headerSubtitleParts.push(enterpriseName);
     if (orgName && !headerTitle.includes(orgName)) headerSubtitleParts.push(orgName);
     addHeader(headerTitle, headerSubtitleParts.join('  •  '));
-        // Summary metrics: render as text grid (3 columns)
-        const metrics = Array.from(document.querySelectorAll('#summaryMetrics .metric-card'))
+        // Summary metrics: render as text grid (3 columns), including AI Credits cost cards.
+        const metrics = Array.from(document.querySelectorAll('#summaryMetrics .metric-card, #creditsMetrics .metric-card'))
             .map(card => ({ label: card.querySelector('.metric-label')?.textContent?.trim(), value: card.querySelector('.metric-value')?.textContent?.trim() }));
         const colCount = 3;
         const colWidth = (pageWidth - margin * 2) / colCount;
@@ -2255,6 +2372,8 @@ function toggleUserUsage(show) {
     if (!section || !chartsSec) return;
     section.hidden = !show;
     chartsSec.hidden = show;
+    const creditsSec = document.getElementById('creditsSection');
+    if (creditsSec && window.__hasCredits) creditsSec.hidden = show;
     if (show) {
         section.scrollIntoView({ behavior: preferredScrollBehavior(), block: 'start' });
         document.getElementById('exportUsersCsvBtn')?.removeAttribute('disabled');
@@ -2265,7 +2384,7 @@ function toggleUserUsage(show) {
     }
 }
 
-function aggregateUserUsage(data) {
+function aggregateUserUsage(data, creditsByUser) {
     const map = new Map();
     data.forEach(r => {
         const login = r.user_login || (r.user_id ? `user-${r.user_id}` : '');
@@ -2284,6 +2403,8 @@ function aggregateUserUsage(data) {
                 cli_days: new Set(),
                 review_active_days: new Set(),
                 review_passive_days: new Set(),
+                cloud_agent_days: new Set(),
+                coding_agent_days: new Set(),
                 models: {},
                 languages: {},
                 features: {},
@@ -2294,7 +2415,8 @@ function aggregateUserUsage(data) {
                 loc_suggested_add: 0,
                 loc_suggested_delete: 0,
                 loc_added: 0,
-                loc_deleted: 0
+                loc_deleted: 0,
+                _adoption: null
             });
         }
         const row = map.get(login);
@@ -2307,6 +2429,17 @@ function aggregateUserUsage(data) {
         if (r.day && (r.used_cli || r.totals_by_cli)) row.cli_days.add(r.day);
         if (r.day && r.used_copilot_code_review_active) row.review_active_days.add(r.day);
         if (r.day && r.used_copilot_code_review_passive) row.review_passive_days.add(r.day);
+        if (r.day && r.used_copilot_cloud_agent) row.cloud_agent_days.add(r.day);
+        if (r.day && r.used_copilot_coding_agent) row.coding_agent_days.add(r.day);
+        if (r.ai_adoption_phase && typeof r.ai_adoption_phase === 'object') {
+            if (!row._adoption || (r.day && r.day >= row._adoption.day)) {
+                row._adoption = {
+                    phase: r.ai_adoption_phase.phase || 'Unknown',
+                    phase_number: toNum(r.ai_adoption_phase.phase_number),
+                    day: r.day || ''
+                };
+            }
+        }
         if (r.totals_by_model_feature) {
             r.totals_by_model_feature.forEach(mf => {
                 const m = mf.model || 'unknown';
@@ -2353,11 +2486,19 @@ function aggregateUserUsage(data) {
         r.cli_days_count = r.cli_days.size;
         r.review_active_days_count = r.review_active_days.size;
         r.review_passive_days_count = r.review_passive_days.size;
+        r.cloud_agent_days_count = r.cloud_agent_days.size;
+        r.coding_agent_days_count = r.coding_agent_days.size;
+        r.adoption_phase = r._adoption ? r._adoption.phase : '';
         r.top_model = topKey(r.models);
         r.top_language = topKey(r.languages);
         r.top_feature = formatFeatureName(topKey(r.features));
         r.top_ide = topKey(r.ides);
         r.top_chat_mode = formatFeatureName(topKey(r.chat_modes));
+        if (creditsByUser) {
+            const entry = creditsByUser.get((r.user_login || '').toLowerCase());
+            r.ai_credits = entry ? entry.credits : 0;
+            r.ai_credit_cost = entry ? entry.cost : 0;
+        }
         return r;
     });
     return rows;
@@ -2370,48 +2511,78 @@ function topKey(obj) {
     return entries[0][0];
 }
 
+function buildUserUsageColumns() {
+    const meta = window.__dashboardModel && window.__dashboardModel.meta;
+    const hasCredits = Boolean(window.__aiCreditsRaw && window.__aiCreditsRaw.length);
+    const cols = [
+        { key: 'user_login', label: 'User', type: 'text', rowHeader: true },
+        { key: 'interactions', label: 'Interactions', type: 'number' },
+        { key: 'completions', label: 'Completions', type: 'number' },
+        { key: 'acceptances', label: 'Acceptances', type: 'number' },
+        { key: 'acceptance_rate', label: 'Acceptance %', type: 'decimal' },
+        { key: 'days_active_count', label: 'Days Active', type: 'number' },
+        { key: 'chat_days_count', label: 'Chat Days', type: 'number' },
+        { key: 'agent_days_count', label: 'Agent Days', type: 'number' },
+        { key: 'cli_days_count', label: 'CLI Days', type: 'number' },
+        { key: 'review_active_days_count', label: 'Review Active Days', type: 'number' },
+        { key: 'review_passive_days_count', label: 'Review Passive Days', type: 'number' }
+    ];
+    if (meta && meta.hasAdoptionPhase) cols.push({ key: 'adoption_phase', label: 'Adoption Phase', type: 'text' });
+    if (meta && meta.hasCloudAgent) cols.push({ key: 'cloud_agent_days_count', label: 'Cloud Agent Days', type: 'number' });
+    if (meta && meta.hasCodingAgent) cols.push({ key: 'coding_agent_days_count', label: 'Coding Agent Days', type: 'number' });
+    cols.push(
+        { key: 'cli_requests', label: 'CLI Requests', type: 'number' },
+        { key: 'cli_sessions', label: 'CLI Sessions', type: 'number' },
+        { key: 'loc_suggested_add', label: 'LoC Suggested', type: 'number' },
+        { key: 'loc_suggested_delete', label: 'LoC Suggested Del', type: 'number' },
+        { key: 'loc_added', label: 'LoC Added', type: 'number' },
+        { key: 'loc_deleted', label: 'LoC Deleted', type: 'number' }
+    );
+    if (hasCredits) {
+        cols.push(
+            { key: 'ai_credits', label: 'AI Credits', type: 'decimal', render: r => escapeHtml(fmtCredits(r.ai_credits)), csv: r => Number(r.ai_credits || 0).toFixed(2) },
+            { key: 'ai_credit_cost', label: 'AI Credit Cost', type: 'currency', render: r => escapeHtml(fmtCurrency(r.ai_credit_cost)), csv: r => Number(r.ai_credit_cost || 0).toFixed(2) }
+        );
+    }
+    cols.push(
+        { key: 'top_model', label: 'Top Model', type: 'text' },
+        { key: 'top_language', label: 'Top Language', type: 'text' },
+        { key: 'top_feature', label: 'Top Feature', type: 'text' },
+        { key: 'top_ide', label: 'Top IDE', type: 'text' },
+        { key: 'top_chat_mode', label: 'Top Chat Mode', type: 'text' }
+    );
+    return cols;
+}
+
+function renderUserUsageCell(col, r) {
+    if (col.render) return col.render(r);
+    const val = r[col.key];
+    if (col.type === 'decimal') return Number(val || 0).toFixed(1);
+    if (col.type === 'number') return String(val ?? 0);
+    return escapeHtml(val === null || val === undefined ? '' : String(val));
+}
+
 function buildUserUsageTable(data) {
     const table = document.getElementById('userUsageTable');
     if (!table) return;
     const thead = table.querySelector('thead');
     const tbody = table.querySelector('tbody');
-    const rows = aggregateUserUsage(data);
+    const creditsByUser = creditsByUserIndex(filterCreditRows(window.__aiCreditsRaw || [], getActiveFilterState()));
+    const rows = aggregateUserUsage(data, creditsByUser);
     window.__userUsageRows = rows;
+    const columns = buildUserUsageColumns();
+    window.__userUsageColumns = columns;
     const exportBtn = document.getElementById('exportUsersCsvBtn');
     // Build head
     thead.innerHTML = '';
     if (!rows.length) {
         if (exportBtn) exportBtn.disabled = true;
-        tbody.innerHTML = '<tr><td colspan="22">No user-level records are available for the current filters.</td></tr>';
+        tbody.innerHTML = `<tr><td colspan="${columns.length}">No user-level records are available for the current filters.</td></tr>`;
         return;
     }
     if (exportBtn) exportBtn.disabled = false;
-    const headers = [
-        { key: 'user_login', label: 'User' },
-        { key: 'interactions', label: 'Interactions' },
-        { key: 'completions', label: 'Completions' },
-        { key: 'acceptances', label: 'Acceptances' },
-        { key: 'acceptance_rate', label: 'Acceptance %' },
-        { key: 'days_active_count', label: 'Days Active' },
-        { key: 'chat_days_count', label: 'Chat Days' },
-        { key: 'agent_days_count', label: 'Agent Days' },
-        { key: 'cli_days_count', label: 'CLI Days' },
-        { key: 'review_active_days_count', label: 'Review Active Days' },
-        { key: 'review_passive_days_count', label: 'Review Passive Days' },
-        { key: 'cli_requests', label: 'CLI Requests' },
-        { key: 'cli_sessions', label: 'CLI Sessions' },
-        { key: 'loc_suggested_add', label: 'LoC Suggested' },
-        { key: 'loc_suggested_delete', label: 'LoC Suggested Del' },
-        { key: 'loc_added', label: 'LoC Added' },
-        { key: 'loc_deleted', label: 'LoC Deleted' },
-        { key: 'top_model', label: 'Top Model' },
-        { key: 'top_language', label: 'Top Language' },
-        { key: 'top_feature', label: 'Top Feature' },
-        { key: 'top_ide', label: 'Top IDE' },
-        { key: 'top_chat_mode', label: 'Top Chat Mode' }
-    ];
     const tr = document.createElement('tr');
-    headers.forEach(h => {
+    columns.forEach(h => {
         const th = document.createElement('th');
         th.dataset.key = h.key;
         th.dataset.label = h.label;
@@ -2442,32 +2613,12 @@ function buildUserUsageTable(data) {
         rows.sort((a,b) => {
             const va = a[key]; const vb = b[key];
             if (typeof va === 'number' && typeof vb === 'number') return (va - vb) * dir;
-            return String(va).localeCompare(String(vb), undefined, { sensitivity: 'base' }) * dir;
+            return String(va ?? '').localeCompare(String(vb ?? ''), undefined, { sensitivity: 'base' }) * dir;
         });
-        tbody.innerHTML = rows.map(r => `<tr>
-            <th scope="row">${escapeHtml(r.user_login)}</th>
-            <td>${r.interactions}</td>
-            <td>${r.completions}</td>
-            <td>${r.acceptances}</td>
-            <td>${r.acceptance_rate.toFixed(1)}</td>
-            <td>${r.days_active_count}</td>
-            <td>${r.chat_days_count}</td>
-            <td>${r.agent_days_count}</td>
-            <td>${r.cli_days_count}</td>
-            <td>${r.review_active_days_count}</td>
-            <td>${r.review_passive_days_count}</td>
-            <td>${r.cli_requests}</td>
-            <td>${r.cli_sessions}</td>
-            <td>${r.loc_suggested_add}</td>
-            <td>${r.loc_suggested_delete}</td>
-            <td>${r.loc_added}</td>
-            <td>${r.loc_deleted}</td>
-            <td>${escapeHtml(r.top_model)}</td>
-            <td>${escapeHtml(r.top_language)}</td>
-            <td>${escapeHtml(r.top_feature)}</td>
-            <td>${escapeHtml(r.top_ide)}</td>
-            <td>${escapeHtml(r.top_chat_mode)}</td>
-        </tr>`).join('');
+        tbody.innerHTML = rows.map(r => '<tr>' + columns.map(col => {
+            const cell = renderUserUsageCell(col, r);
+            return col.rowHeader ? `<th scope="row">${cell}</th>` : `<td>${cell}</td>`;
+        }).join('') + '</tr>').join('');
         thead.querySelectorAll('th.sortable').forEach(th => {
             const isActive = th.dataset.key === key;
             const label = th.dataset.label || th.dataset.key;
@@ -2488,61 +2639,35 @@ function buildUserUsageTable(data) {
 }
 
 function exportUserUsageCsv() {
-    const rows = window.__userUsageRows || aggregateUserUsage(window.__currentFilteredData || window.__rawData || []);
+    let rows = window.__userUsageRows;
+    let columns = window.__userUsageColumns;
+    if (!rows || !columns) {
+        const creditsByUser = creditsByUserIndex(filterCreditRows(window.__aiCreditsRaw || [], getActiveFilterState()));
+        rows = aggregateUserUsage(window.__currentFilteredData || window.__rawData || [], creditsByUser);
+        columns = buildUserUsageColumns();
+    }
     if (!rows.length) { setStatus('No per-user rows are available to export for the current filters.', true); return; }
-    const header = [
-        'user_login',
-        'user_id',
-        'interactions',
-        'completions',
-        'acceptances',
-        'acceptance_rate',
-        'days_active',
-        'chat_days',
-        'agent_days',
-        'cli_days',
-        'review_active_days',
-        'review_passive_days',
-        'cli_requests',
-        'cli_sessions',
-        'loc_suggested_add',
-        'loc_suggested_delete',
-        'loc_added',
-        'loc_deleted',
-        'top_model',
-        'top_language',
-        'top_feature',
-        'top_ide',
-        'top_chat_mode'
-    ];
-    const lines = [header.join(',')];
+    const csvValue = (col, r) => {
+        if (col.csv) return col.csv(r);
+        const val = r[col.key];
+        if (col.type === 'decimal') return Number(val || 0).toFixed(2);
+        if (col.type === 'number') return val ?? 0;
+        return val ?? '';
+    };
+    // Include user_id right after the user column for traceability.
+    const header = [];
+    columns.forEach(col => {
+        header.push(col.key);
+        if (col.key === 'user_login') header.push('user_id');
+    });
+    const lines = [header.map(csvEscape).join(',')];
     rows.forEach(r => {
-        const vals = [
-            r.user_login,
-            r.user_id,
-            r.interactions,
-            r.completions,
-            r.acceptances,
-            r.acceptance_rate.toFixed(2),
-            r.days_active_count,
-            r.chat_days_count,
-            r.agent_days_count,
-            r.cli_days_count,
-            r.review_active_days_count,
-            r.review_passive_days_count,
-            r.cli_requests,
-            r.cli_sessions,
-            r.loc_suggested_add,
-            r.loc_suggested_delete,
-            r.loc_added,
-            r.loc_deleted,
-            r.top_model,
-            r.top_language,
-            r.top_feature,
-            r.top_ide,
-            r.top_chat_mode
-        ].map(v => csvEscape(v));
-        lines.push(vals.join(','));
+        const vals = [];
+        columns.forEach(col => {
+            vals.push(csvValue(col, r));
+            if (col.key === 'user_login') vals.push(r.user_id);
+        });
+        lines.push(vals.map(csvEscape).join(','));
     });
     const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
@@ -2558,4 +2683,355 @@ function csvEscape(val) {
     const s = String(val);
     if (/[",\n]/.test(s)) return '"' + s.replace(/"/g,'""') + '"';
     return s;
+}
+
+// ================= AI Credits (premium request) report ================= //
+
+// Minimal RFC-4180 CSV parser: returns an array of string[] rows.
+function parseCsv(text) {
+    if (typeof text !== 'string') return [];
+    // Strip UTF-8 BOM if present.
+    if (text.charCodeAt(0) === 0xFEFF) text = text.slice(1);
+    const rows = [];
+    let row = [];
+    let field = '';
+    let inQuotes = false;
+    for (let i = 0; i < text.length; i++) {
+        const ch = text[i];
+        if (inQuotes) {
+            if (ch === '"') {
+                if (text[i + 1] === '"') { field += '"'; i++; }
+                else inQuotes = false;
+            } else {
+                field += ch;
+            }
+            continue;
+        }
+        if (ch === '"') { inQuotes = true; continue; }
+        if (ch === ',') { row.push(field); field = ''; continue; }
+        if (ch === '\r') { continue; }
+        if (ch === '\n') { row.push(field); rows.push(row); row = []; field = ''; continue; }
+        field += ch;
+    }
+    // Flush trailing field/row.
+    if (field.length || row.length) { row.push(field); rows.push(row); }
+    return rows;
+}
+
+const AI_CREDITS_NUMERIC_FIELDS = new Set([
+    'quantity',
+    'applied_cost_per_quantity',
+    'gross_amount',
+    'discount_amount',
+    'net_amount',
+    'total_monthly_quota',
+    'aic_quantity',
+    'aic_gross_amount'
+]);
+
+function parseAiCreditsCsv(text) {
+    const rows = parseCsv(text).filter(r => r.some(cell => (cell || '').trim() !== ''));
+    if (rows.length < 2) throw new Error('The CSV appears to be empty or has no data rows.');
+    const header = rows[0].map(h => (h || '').trim().toLowerCase());
+    const required = ['date', 'model', 'quantity', 'net_amount', 'unit_type'];
+    const missing = required.filter(col => !header.includes(col));
+    if (missing.length) {
+        throw new Error(`Missing expected column(s): ${missing.join(', ')}. This does not look like an AI Credits usage report.`);
+    }
+    const out = [];
+    for (let i = 1; i < rows.length; i++) {
+        const cells = rows[i];
+        const obj = {};
+        header.forEach((name, idx) => {
+            if (!name) return;
+            const raw = (cells[idx] ?? '').trim();
+            obj[name] = AI_CREDITS_NUMERIC_FIELDS.has(name) ? toNum(raw) : raw;
+        });
+        const model = obj.model || 'unknown';
+        obj.is_auto = /^auto:/i.test(model);
+        obj.base_model = model.replace(/^auto:\s*/i, '').trim() || model;
+        out.push(obj);
+    }
+    return out;
+}
+
+function fmtCurrency(value) {
+    return '$' + Number(value || 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function fmtCredits(value) {
+    return Number(value || 0).toLocaleString(undefined, { maximumFractionDigits: 1 });
+}
+
+function getActiveFilterState() {
+    return {
+        search: (document.getElementById('userSearch')?.value || '').trim().toLowerCase(),
+        from: document.getElementById('dateFrom')?.value || '',
+        to: document.getElementById('dateTo')?.value || '',
+        membersOnly: !!document.getElementById('membersOnlyChk')?.checked
+    };
+}
+
+function filterCreditRows(rows, state) {
+    let filtered = rows || [];
+    if (!filtered.length) return filtered;
+    const s = state || getActiveFilterState();
+    if (s.search) filtered = filtered.filter(r => (r.username || '').toLowerCase().includes(s.search));
+    if (s.from) filtered = filtered.filter(r => !r.date || r.date >= s.from);
+    if (s.to) filtered = filtered.filter(r => !r.date || r.date <= s.to);
+    if (s.membersOnly && window.__membersSet) {
+        filtered = filtered.filter(r => window.__membersSet.has((r.username || '').toLowerCase()));
+    }
+    return filtered;
+}
+
+function creditsByUserIndex(rows) {
+    const map = new Map();
+    (rows || []).forEach(r => {
+        const login = (r.username || '').trim();
+        if (!login) return;
+        const key = login.toLowerCase();
+        const entry = map.get(key) || { login, credits: 0, cost: 0 };
+        entry.credits += toNum(r.quantity);
+        entry.cost += toNum(r.net_amount);
+        map.set(key, entry);
+    });
+    return map;
+}
+
+function buildCreditsModel(rows) {
+    if (!rows || !rows.length) return null;
+    const groupSum = keyFn => {
+        const m = new Map();
+        rows.forEach(r => {
+            const key = keyFn(r);
+            const g = m.get(key) || { key, credits: 0, net_cost: 0, gross_cost: 0 };
+            g.credits += toNum(r.quantity);
+            g.net_cost += toNum(r.net_amount);
+            g.gross_cost += toNum(r.gross_amount);
+            m.set(key, g);
+        });
+        return m;
+    };
+
+    let credits = 0, netCost = 0, grossCost = 0, discount = 0, aicCredits = 0, aicGross = 0, monthlyQuota = 0;
+    let autoCredits = 0, manualCredits = 0, autoCost = 0, manualCost = 0;
+    const userSet = new Set();
+    const orgSet = new Set();
+    rows.forEach(r => {
+        credits += toNum(r.quantity);
+        netCost += toNum(r.net_amount);
+        grossCost += toNum(r.gross_amount);
+        discount += toNum(r.discount_amount);
+        aicCredits += toNum(r.aic_quantity);
+        aicGross += toNum(r.aic_gross_amount);
+        monthlyQuota = Math.max(monthlyQuota, toNum(r.total_monthly_quota));
+        if (r.username) userSet.add(r.username.toLowerCase());
+        if (r.organization) orgSet.add(r.organization);
+        if (r.is_auto) { autoCredits += toNum(r.quantity); autoCost += toNum(r.net_amount); }
+        else { manualCredits += toNum(r.quantity); manualCost += toNum(r.net_amount); }
+    });
+
+    const byCreditsDesc = (a, b) => b.credits - a.credits;
+    const withShare = list => list.map(row => ({ ...row, share: credits ? (row.credits / credits) * 100 : 0 }));
+    const byModel = withShare(Array.from(groupSum(r => r.model || 'unknown').values()).sort(byCreditsDesc));
+    const byUser = Array.from(groupSum(r => r.username || '(unattributed)').values()).sort(byCreditsDesc);
+    const byOrg = Array.from(groupSum(r => r.organization || '(none)').values()).sort(byCreditsDesc);
+    const byCostCenter = Array.from(groupSum(r => r.cost_center_name || '(none)').values()).sort(byCreditsDesc);
+    const byRepo = Array.from(groupSum(r => r.repository || '(none)').values()).sort(byCreditsDesc);
+    const byDay = Array.from(groupSum(r => r.date || '').values())
+        .filter(row => row.key)
+        .sort((a, b) => a.key.localeCompare(b.key));
+
+    const users = userSet.size;
+    const avgCreditsPerUser = users ? credits / users : 0;
+    const quotaPct = monthlyQuota ? (avgCreditsPerUser / monthlyQuota) * 100 : 0;
+
+    return {
+        rows,
+        totals: {
+            credits, netCost, grossCost, discount, aicCredits, aicGross,
+            monthlyQuota, users, models: byModel.length, orgs: orgSet.size,
+            avgCreditsPerUser, quotaPct,
+            topModel: byModel[0]?.key || 'n/a',
+            autoCredits, manualCredits, autoCost, manualCost
+        },
+        breakdowns: { byModel, byUser, byOrg, byCostCenter, byRepo, byDay }
+    };
+}
+
+function renderAiCreditsSection(cm) {
+    const section = document.getElementById('creditsSection');
+    const metricsEl = document.getElementById('creditsMetrics');
+    const chartsEl = document.getElementById('creditsCharts');
+    const tablesEl = document.getElementById('creditsTables');
+    if (!section || !metricsEl || !chartsEl || !tablesEl) return;
+
+    if (!cm || !cm.rows.length) {
+        window.__hasCredits = false;
+        section.hidden = true;
+        metricsEl.innerHTML = '';
+        chartsEl.innerHTML = '';
+        tablesEl.innerHTML = '';
+        return;
+    }
+
+    window.__hasCredits = true;
+    section.hidden = false;
+    const t = cm.totals;
+
+    const cards = [
+        { label: 'Total AI Credits', value: fmtCredits(t.credits) },
+        { label: 'Total Cost (Net)', value: fmtCurrency(t.netCost) },
+        { label: 'Gross Cost', value: fmtCurrency(t.grossCost) }
+    ];
+    if (t.discount > 0) cards.push({ label: 'Discounts', value: fmtCurrency(t.discount) });
+    cards.push(
+        { label: 'Users with Spend', value: t.users.toLocaleString() },
+        { label: 'Avg Credits / User', value: fmtCredits(t.avgCreditsPerUser) },
+        { label: 'Most Expensive Model', value: t.topModel }
+    );
+    if (t.monthlyQuota > 0) {
+        cards.push(
+            { label: 'Monthly Quota / User', value: fmtCredits(t.monthlyQuota) },
+            { label: 'Avg vs Monthly Quota %', value: t.quotaPct.toFixed(1) }
+        );
+    }
+    if (t.aicCredits > 0) {
+        cards.push(
+            { label: 'Additional (Overage) Credits', value: fmtCredits(t.aicCredits) },
+            { label: 'Overage Cost', value: fmtCurrency(t.aicGross) }
+        );
+    }
+    const note = `<div class="small-note" style="grid-column:1 / -1; margin-top:8px;">1 AI credit = $0.01. Monthly quota is per user; "Avg vs Monthly Quota %" is scoped to the selected date range. Rows without a username (repository- or agent-scoped usage) are included in totals but not in the per-user table.</div>`;
+    metricsEl.innerHTML = cards.map(c => metricCard(c.label, c.value)).join('') + note;
+
+    // Charts
+    chartsEl.innerHTML = '';
+    const topModels = cm.breakdowns.byModel.slice(0, 8);
+    if (topModels.length) {
+        createChart('AI Credits by Model', 'doughnut', topModels.map(r => r.key), topModels.map(r => +r.credits.toFixed(2)), chartsEl);
+    }
+    if (cm.breakdowns.byDay.length) {
+        createStackedChart('AI Credits per Day', cm.breakdowns.byDay.map(r => r.key), [
+            { name: 'AI Credits', data: cm.breakdowns.byDay.map(r => +r.credits.toFixed(2)) }
+        ], 'area', 'normal', chartsEl);
+        createStackedChart('Daily Net Cost ($)', cm.breakdowns.byDay.map(r => r.key), [
+            { name: 'Net cost', data: cm.breakdowns.byDay.map(r => +r.net_cost.toFixed(2)) }
+        ], 'area', 'normal', chartsEl);
+    }
+    const topUsers = cm.breakdowns.byUser.filter(r => r.key !== '(unattributed)').slice(0, 10);
+    if (topUsers.length) {
+        createChart('Top Users by AI Credits', 'bar', topUsers.map(r => r.key), topUsers.map(r => +r.credits.toFixed(2)), chartsEl);
+    }
+    const orgs = cm.breakdowns.byOrg.filter(r => r.key !== '(none)');
+    if (orgs.length > 1) {
+        createChart('AI Credits by Organization', 'column', orgs.slice(0, 12).map(r => r.key), orgs.slice(0, 12).map(r => +r.credits.toFixed(2)), chartsEl);
+    }
+    const costCenters = cm.breakdowns.byCostCenter.filter(r => r.key !== '(none)');
+    if (costCenters.length) {
+        createChart('AI Credits by Cost Center', 'column', costCenters.slice(0, 12).map(r => r.key), costCenters.slice(0, 12).map(r => +r.credits.toFixed(2)), chartsEl);
+    }
+    if (t.autoCredits > 0 && t.manualCredits > 0) {
+        createChart('Auto vs Manual Model Credits', 'pie', ['Auto-selected', 'Manually selected'], [+t.autoCredits.toFixed(2), +t.manualCredits.toFixed(2)], chartsEl);
+    }
+
+    // Tables
+    const currencyCol = (key, label) => ({ key, label, render: value => escapeHtml(fmtCurrency(value)) });
+    const creditsCol = { key: 'credits', label: 'Credits', render: value => escapeHtml(fmtCredits(value)) };
+    const blocks = [];
+    blocks.push(renderTableBlock(
+        'AI credits by model',
+        'Premium request credits and cost grouped by model (auto-selected models keep their "Auto:" label).',
+        [
+            { key: 'key', label: 'Model' },
+            creditsCol,
+            currencyCol('net_cost', 'Net cost'),
+            currencyCol('gross_cost', 'Gross cost'),
+            { key: 'share', label: 'Share %', type: 'decimal' }
+        ],
+        cm.breakdowns.byModel,
+        true
+    ));
+    if (cm.breakdowns.byUser.length) {
+        blocks.push(renderTableBlock(
+            'AI credits by user',
+            'Credits and cost grouped by username. Rows without a username are grouped as "(unattributed)".',
+            [{ key: 'key', label: 'User' }, creditsCol, currencyCol('net_cost', 'Net cost')],
+            cm.breakdowns.byUser
+        ));
+    }
+    const orgRows = cm.breakdowns.byOrg;
+    if (orgRows.length) {
+        blocks.push(renderTableBlock(
+            'AI credits by organization',
+            'Credits and cost grouped by organization.',
+            [{ key: 'key', label: 'Organization' }, creditsCol, currencyCol('net_cost', 'Net cost')],
+            orgRows
+        ));
+    }
+    if (costCenters.length) {
+        blocks.push(renderTableBlock(
+            'AI credits by cost center',
+            'Credits and cost grouped by cost center (only rows with a cost center are shown).',
+            [{ key: 'key', label: 'Cost center' }, creditsCol, currencyCol('net_cost', 'Net cost')],
+            costCenters
+        ));
+    }
+    tablesEl.innerHTML = blocks.join('');
+
+    enableDownloadButton();
+}
+
+function updateCreditsView() {
+    const raw = window.__aiCreditsRaw;
+    if (!raw || !raw.length) { renderAiCreditsSection(null); return; }
+    const filtered = filterCreditRows(raw, getActiveFilterState());
+    renderAiCreditsSection(buildCreditsModel(filtered));
+}
+
+function refreshDateBoundsUnion() {
+    const creditDates = (window.__aiCreditsRaw || []).map(r => r.date).filter(Boolean);
+    const metricDays = window.__allDays || [];
+    const all = Array.from(new Set([...metricDays, ...creditDates])).filter(Boolean).sort();
+    if (!all.length) return;
+    window.__allDays = all;
+    const min = all[0];
+    const max = all[all.length - 1];
+    const from = document.getElementById('dateFrom');
+    const to = document.getElementById('dateTo');
+    // Widen the active range so newly added credit dates outside the current
+    // metrics window are not silently filtered out (never narrows the range).
+    if (from) { from.min = min; from.max = max; if (!from.value || from.value > min) from.value = min; }
+    if (to) { to.min = min; to.max = max; if (!to.value || to.value < max) to.value = max; }
+    setupQuickRangeButtons();
+}
+
+function handleAiCreditsFile(file) {
+    if (!file) { setStatus('No AI Credits file selected. Please choose a CSV export.'); return; }
+    showLoading(true);
+    setStatus(`Reading ${file.name} …`);
+    const reader = new FileReader();
+    reader.onload = e => {
+        try {
+            const rows = parseAiCreditsCsv(e.target.result);
+            if (!rows.length) throw new Error('No AI credit rows found in the file.');
+            window.__aiCreditsRaw = rows;
+            if (window.__rawData && window.__rawData.length) {
+                refreshDateBoundsUnion();
+                applyFilters();
+            } else {
+                initializeFilters(rows.map(r => ({ day: r.date })));
+                analyzeData([]);
+            }
+            setStatus(`Loaded ${rows.length} AI credit rows from ${file.name}. Cost views updated.`);
+        } catch (err) {
+            console.error(err);
+            setStatus(`AI Credits parse error: ${err.message}`, true);
+        } finally {
+            showLoading(false);
+        }
+    };
+    reader.onerror = () => { setStatus('AI Credits file read error', true); showLoading(false); };
+    reader.readAsText(file);
 }

--- a/script.js
+++ b/script.js
@@ -302,7 +302,85 @@ document.addEventListener('DOMContentLoaded', () => {
     if (exportUsersCsvBtn) {
         exportUsersCsvBtn.addEventListener('click', () => exportUserUsageCsv());
     }
+
+    initializeHeaderHeightVar();
+    initializeSectionNav();
+    initializeBackToTop();
 });
+
+function initializeHeaderHeightVar() {
+    const header = document.querySelector('header.app-header');
+    if (!header) return;
+    const setVar = () => {
+        document.documentElement.style.setProperty('--header-h', header.offsetHeight + 'px');
+    };
+    setVar();
+    if (typeof ResizeObserver === 'function') {
+        new ResizeObserver(setVar).observe(header);
+    } else {
+        window.addEventListener('resize', setVar);
+    }
+}
+
+function initializeSectionNav() {
+    const nav = document.querySelector('.section-nav');
+    if (!nav) return;
+
+    // Smooth-scroll to the target section and move focus for accessibility.
+    nav.addEventListener('click', (e) => {
+        const link = e.target.closest('a[href^="#"]');
+        if (!link) return;
+        const id = link.getAttribute('href').slice(1);
+        const target = document.getElementById(id);
+        if (!target) return;
+        e.preventDefault();
+        target.scrollIntoView({ behavior: preferredScrollBehavior(), block: 'start' });
+        if (!target.hasAttribute('tabindex')) target.setAttribute('tabindex', '-1');
+        target.focus({ preventScroll: true });
+        if (window.history && typeof window.history.replaceState === 'function') {
+            window.history.replaceState(null, '', '#' + id);
+        }
+    });
+
+    // Keep each jump link in sync with its section's visibility.
+    const toggleable = ['chartsSection', 'creditsSection', 'tablesSection', 'userUsageSection'];
+    const sync = (sectionId) => {
+        const li = nav.querySelector('li[data-section-link="' + sectionId + '"]');
+        const section = document.getElementById(sectionId);
+        if (li && section) li.hidden = !!section.hidden;
+    };
+    toggleable.forEach((sectionId) => {
+        const section = document.getElementById(sectionId);
+        if (!section) return;
+        sync(sectionId);
+        new MutationObserver(() => sync(sectionId))
+            .observe(section, { attributes: true, attributeFilter: ['hidden'] });
+    });
+}
+
+function initializeBackToTop() {
+    const btn = document.getElementById('backToTopBtn');
+    if (!btn) return;
+    const showAfter = 320;
+    let ticking = false;
+    const update = () => {
+        ticking = false;
+        const y = window.scrollY || document.documentElement.scrollTop || 0;
+        btn.classList.toggle('is-visible', y > showAfter);
+    };
+    const onScroll = () => {
+        if (ticking) return;
+        ticking = true;
+        window.requestAnimationFrame(update);
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    update();
+    btn.addEventListener('click', () => {
+        window.scrollTo({ top: 0, left: 0, behavior: preferredScrollBehavior() });
+        const main = document.getElementById('mainContent');
+        if (main) main.focus({ preventScroll: true });
+    });
+}
 
 function syncSelectedFileName(inputEl, outputId, emptyText = 'No file chosen') {
     const outputEl = document.getElementById(outputId);

--- a/script.js
+++ b/script.js
@@ -303,6 +303,11 @@ document.addEventListener('DOMContentLoaded', () => {
         exportUsersCsvBtn.addEventListener('click', () => exportUserUsageCsv());
     }
 
+    const clearDataBtn = document.getElementById('clearDataBtn');
+    if (clearDataBtn) {
+        clearDataBtn.addEventListener('click', () => clearAllData());
+    }
+
     initializeHeaderHeightVar();
     initializeSectionNav();
     initializeBackToTop();
@@ -660,6 +665,7 @@ function analyzeData(data) {
         if (downloadBtn) downloadBtn.disabled = true;
         const userUsageBtn = document.getElementById('userUsageBtn');
         if (userUsageBtn) userUsageBtn.disabled = true;
+        updateClearButtonState();
         updateCreditsView();
         return;
     }
@@ -673,6 +679,7 @@ function analyzeData(data) {
     renderReferenceTables(model);
     updateCreditsView();
     enableDownloadButton();
+    updateClearButtonState();
 
     const userUsageBtn = document.getElementById('userUsageBtn');
     if (userUsageBtn) userUsageBtn.disabled = !model.meta.hasUserRecords;
@@ -2086,6 +2093,80 @@ function enableDownloadButton() {
     if (btn) btn.disabled = false;
     const uBtn = document.getElementById('userUsageBtn');
     if (uBtn) uBtn.disabled = !(window.__dashboardModel && window.__dashboardModel.meta.hasUserRecords);
+}
+
+function updateClearButtonState() {
+    const btn = document.getElementById('clearDataBtn');
+    if (!btn) return;
+    const hasMetrics = Boolean(window.__rawData && window.__rawData.length);
+    const hasCredits = Boolean(window.__aiCreditsRaw && window.__aiCreditsRaw.length);
+    btn.disabled = !(hasMetrics || hasCredits);
+}
+
+function clearAllData() {
+    // Drop loaded datasets and any derived state.
+    window.__rawData = null;
+    window.__sourceData = null;
+    window.__aiCreditsRaw = null;
+    window.__currentFilteredData = null;
+    window.__dashboardModel = null;
+    window.__membersSet = null;
+    window.__allDays = [];
+    window.__hasCredits = false;
+
+    // Reset the file inputs and their displayed names.
+    ['jsonFileInput', 'aiCreditsFileInput', 'membersFileInput'].forEach(id => {
+        const input = document.getElementById(id);
+        if (input) input.value = '';
+    });
+    syncSelectedFileName(document.getElementById('jsonFileInput'), 'jsonFileName');
+    syncSelectedFileName(document.getElementById('aiCreditsFileInput'), 'aiCreditsFileName');
+
+    // Reset filter controls back to their empty defaults.
+    const search = document.getElementById('userSearch');
+    if (search) search.value = '';
+    ['dateFrom', 'dateTo'].forEach(id => {
+        const el = document.getElementById(id);
+        if (el) { el.value = ''; el.removeAttribute('min'); el.removeAttribute('max'); }
+    });
+    document.querySelectorAll('.range-btn').forEach(btn => {
+        btn.classList.remove('active');
+        btn.setAttribute('aria-pressed', 'false');
+    });
+    updateMembersStatus();
+
+    // Return to the dashboard view and clear rendered content.
+    const userUsageSection = document.getElementById('userUsageSection');
+    if (userUsageSection) userUsageSection.hidden = true;
+    const chartsSection = document.getElementById('chartsSection');
+    if (chartsSection) chartsSection.hidden = false;
+    const userTable = document.getElementById('userUsageTable');
+    if (userTable) {
+        const thead = userTable.querySelector('thead');
+        const tbody = userTable.querySelector('tbody');
+        if (thead) thead.innerHTML = '';
+        if (tbody) tbody.innerHTML = '';
+    }
+    const tablesContainer = document.getElementById('tablesContainer');
+    if (tablesContainer) tablesContainer.innerHTML = '';
+    const tablesSection = document.getElementById('tablesSection');
+    if (tablesSection) tablesSection.hidden = true;
+    updateCreditsView(); // no credits -> hides and clears the cost section
+
+    // Disable the data-dependent actions.
+    ['applyFiltersBtn', 'downloadPdfBtn', 'userUsageBtn', 'exportUsersCsvBtn', 'clearDataBtn'].forEach(id => {
+        const btn = document.getElementById(id);
+        if (btn) btn.disabled = true;
+    });
+
+    // Restore the initial empty state.
+    renderPlaceholders('upload');
+    setStatus('Cleared all loaded data. Upload a JSON or JSON Lines file to populate the dashboard.');
+
+    // Send the user back to the top and refocus the metrics file picker.
+    window.scrollTo({ top: 0, left: 0, behavior: preferredScrollBehavior() });
+    const trigger = document.getElementById('jsonFileTrigger');
+    if (trigger) trigger.focus();
 }
 
 function escapeHtml(str) {

--- a/script.js
+++ b/script.js
@@ -1728,8 +1728,8 @@ function createHeatmap(title, xCategories, yCategories, dataPoints, colorAxisTit
     Highcharts.chart(div, {
     chart: { type: 'heatmap', backgroundColor: 'transparent', height: 480 },
         title: { text: title, style: { fontSize: '15px' } },
-        xAxis: { categories: xCategories, labels: { style: { fontSize: '12px' }, rotation: 40 } },
-        yAxis: { categories: yCategories, title: null, labels: { style: { fontSize: '12px' } }, reversed: true },
+        xAxis: { categories: xCategories, type: 'category', min: 0, max: Math.max(0, xCategories.length - 1), tickInterval: 1, labels: { style: { fontSize: '12px' }, rotation: 40 } },
+        yAxis: { categories: yCategories, type: 'category', title: null, min: 0, max: Math.max(0, yCategories.length - 1), tickInterval: 1, labels: { style: { fontSize: '12px' } }, reversed: true },
         accessibility: { enabled: true },
         legend: { align: 'right', layout: 'vertical', verticalAlign: 'middle' },
         colorAxis: {

--- a/style.css
+++ b/style.css
@@ -42,6 +42,7 @@ html {
     --radius-sm: 10px;
     --radius: 16px;
     --radius-lg: 22px;
+    --header-h: 76px;
     --shadow: 0 20px 44px -34px rgb(27 53 88 / 30%), 0 10px 24px -18px rgb(27 53 88 / 18%);
     --shadow-hover: 0 18px 30px -26px rgb(27 53 88 / 30%);
     --status-info-border: #bfd8ff;
@@ -1498,6 +1499,104 @@ summary:focus-visible,
     outline-offset: 2px;
 }
 
+/* ===== Jump-to-section nav ===== */
+.section-nav {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.45rem 0.7rem;
+    margin: 0 0 1.5rem;
+    padding: 0.55rem 0.7rem;
+    border: 1px solid var(--panel-border);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--panel) 88%, var(--bg-alt) 12%);
+    box-shadow: var(--shadow);
+}
+
+.section-nav-label {
+    padding-inline: 0.5rem;
+    color: var(--text-soft);
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.11em;
+    text-transform: uppercase;
+}
+
+.section-nav-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.section-nav a {
+    display: inline-flex;
+    align-items: center;
+    min-height: 40px;
+    padding: 0.4rem 0.85rem;
+    border: 1px solid var(--panel-border);
+    border-radius: 999px;
+    color: var(--accent-strong);
+    background: var(--panel);
+    font-size: 0.82rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    text-decoration: none;
+    transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+.section-nav a:hover {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+    color: var(--accent-strong);
+}
+
+/* Offset anchor targets so the sticky header does not cover section headings */
+main section[id] {
+    scroll-margin-top: calc(var(--header-h, 76px) + 16px);
+}
+
+/* ===== Back-to-top floating button ===== */
+.back-to-top {
+    position: fixed;
+    right: clamp(1rem, 2.5vw, 2rem);
+    bottom: clamp(1rem, 2.5vw, 2rem);
+    z-index: 50;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    padding: 0;
+    border: 1px solid var(--accent-strong);
+    border-radius: 999px;
+    background: linear-gradient(180deg, var(--accent) 0%, var(--accent-strong) 100%);
+    color: var(--text-on-accent);
+    box-shadow: var(--shadow), var(--primary-shadow);
+    cursor: pointer;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(12px) scale(0.92);
+    transition: opacity 0.22s ease, transform 0.22s ease, visibility 0.22s ease, box-shadow 0.18s ease;
+}
+
+.back-to-top.is-visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0) scale(1);
+}
+
+.back-to-top:hover {
+    transform: translateY(-2px) scale(1.04);
+    box-shadow: var(--shadow-hover), var(--primary-shadow-hover);
+}
+
+.back-to-top svg {
+    display: block;
+}
+
 @media (prefers-reduced-motion: reduce) {
     html {
         scroll-behavior: auto;
@@ -1630,6 +1729,11 @@ summary:focus-visible,
         padding: 0.72rem 0.78rem;
         font-size: 0.85rem;
     }
+
+    .back-to-top {
+        width: 44px;
+        height: 44px;
+    }
 }
 
 @media print {
@@ -1640,6 +1744,8 @@ summary:focus-visible,
     .app-header,
     .controls-panel,
     .app-footer,
+    .section-nav,
+    .back-to-top,
     .loading-overlay {
         display: none !important;
     }
@@ -1660,6 +1766,11 @@ body.printing .app-header,
 body.printing .controls-panel,
 body.printing .app-footer {
     opacity: 0.3;
+}
+
+body.printing .section-nav,
+body.printing .back-to-top {
+    display: none !important;
 }
 
 body.printing .actions-row #downloadPdfBtn {

--- a/style.css
+++ b/style.css
@@ -926,6 +926,17 @@ button.secondary:hover:not(:disabled),
     color: var(--accent-strong);
 }
 
+button.secondary.danger-action {
+    border-color: color-mix(in srgb, var(--danger) 34%, var(--panel-border-strong));
+    color: var(--danger);
+}
+
+button.secondary.danger-action:hover:not(:disabled) {
+    border-color: var(--danger);
+    background: var(--danger-soft);
+    color: var(--danger);
+}
+
 button:disabled {
     cursor: not-allowed;
     opacity: 0.52;


### PR DESCRIPTION
## Why

The GitHub Copilot usage-metrics export has grown new per-user signals, and teams now also get a separate **AI Credits (premium request) usage report** for billing. This dashboard didn't understand either, so cost analysis had to happen outside the tool and the newest adoption signals were invisible. This PR brings the analyzer up to the current schema, adds first-class AI Credits cost analysis, and smooths out a few rough edges in the UI. Everything stays 100% client-side and local.

## What changed

**Latest usage-metrics fields**
- Parses and surfaces new per-user signals: `ai_adoption_phase`, `used_copilot_cloud_agent`, and `used_copilot_coding_agent`.
- Adds summary cards (Top Adoption Phase, Coding/Cloud Agent Users), an "AI Adoption Phase Distribution" chart, and an "AI adoption phases" reference table, shown only when those fields are present.

**AI Credits & cost (new, optional)**
- New CSV upload with an RFC-4180 parser (handles BOM and quoted fields), header validation, and `Auto:`-model detection (1 AI credit = $0.01).
- A dedicated "AI Credits & cost" section with cards, charts (credits by model, per-day credit/cost, top users, by org/cost center, auto vs manual model), and tables. It respects the existing date, user-search, and members-only filters.
- The report can load on its own (cost-only) or alongside a metrics export. When both are present, per-user credits and cost merge into the user table and CSV export (matched by username, case-insensitive). Date bounds now union metric days with credit dates so out-of-window credit dates stay visible.
- AI Credits cards and charts are included in the PDF export.

**UX and fixes**
- Fixed a Highcharts load failure by switching the CDN to cdnjs (`code.highcharts.com` returns 403 in some networks).
- Fixed the "Language Usage by Model" heatmap, which rendered raw indices instead of language names on the axis.
- Added a "Jump to" section nav and a floating back-to-top button; nav links auto-hide for sections that aren't populated.
- Added a "Clear" button that wipes all loaded data and returns the app to its empty upload state (distinct from "Reset", which only resets filters). It is disabled until data is loaded and styled as a subtle destructive action.

## Notes for reviewers

- No build step. Since assets are served statically, the `?v=` cache-bust token on `style.css` and `script.js` in `index.html` is bumped so browsers pick up the new files.
- Highcharts is pinned to cdnjs 11.4.8 (the v12 cdnjs build is ES-module-only with no UMD bundle, which this no-bundler app can't consume).
- All new sections and columns are additive and gated on field presence, so older exports render exactly as before.

## Testing

Verified end-to-end in the browser (Playwright) across load, filter, user-table, clear, and re-load flows with 0 console errors; light and dark themes checked.