### PR TITLE
Improve dashboard navigation and user table

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Please note this is not an official solution from GitHub.**
 
-This is a local, client‑side dashboard for exploring GitHub Copilot usage exports. It supports both **local file uploads** and **direct GitHub API integration** for organization members filtering. No data is uploaded to a server: everything stays in your browser.
+This is a local, client‑side dashboard for exploring GitHub Copilot usage exports. It supports both **local file uploads** and **direct GitHub API integration** for organization members filtering. No data is uploaded to a server: everything stays in your browser. Analysis is organized into page-style views for **Overview**, **Charts**, **AI Credits**, **Reference Tables**, and **Users** while preserving the loaded data in memory.
 
 The dashboard now handles both:
 * **User-level records** (for per-user analysis, user flags, and CSV export)
@@ -88,7 +88,7 @@ The dashboard now supports two data sources:
 
 ### 4. Load data
 1. Click “Upload Copilot Metrics JSON” and choose your export file.
-2. The status message will show progress; once parsed, summary metric cards and charts render automatically.
+2. The status message will show progress; once parsed, the **Overview** page opens automatically and the Load & Filter drawer collapses to a compact file, record-count, date-range, and active-filter summary. Reopen it at any time to change the data or filters.
 3. (Optional) Upload the members file to activate the “Members only” checkbox.
 
 Screenshots:
@@ -100,7 +100,7 @@ Screenshots:
 ---
 
 ### 4. Use filters & quick ranges
-* User Search: type part of a login (case‑insensitive) to narrow results.
+* Dashboard User Filter: type part of a login (case‑insensitive) to narrow metrics across every page.
 * Date Range: set explicit From / To days, or use quick buttons (7d / 14d / 28d / All) for instant ranges.
 * Members only: after loading a members file, restrict metrics to those users.
 * Apply Filters: re‑computes the summary cards and all charts with current criteria.
@@ -109,7 +109,9 @@ Screenshots:
 ### 5. Explore the metrics
 Summary cards now reflect the latest Copilot usage metrics reference, including active-user rollups, chat usage, AI Credits used, LoC changed with AI, agent contribution, CLI usage, code review activity, and pull request totals when present in the export.
 
-Below them, the dashboard renders updated chart groups for:
+Use the page navigation above the Load & Filter drawer to move between the Overview, Charts, Reference Tables, and Users views without reloading the uploaded data. The AI Credits page appears when an AI Credits usage report is loaded.
+
+The Charts page renders updated chart groups for:
 * Adoption, usage, AI Credits used per day, and chat modes (including **AI adoption phase distribution**)
 * Model usage (overall, per day, per chat mode, per language)
 * Language usage (overall and per day)
@@ -131,7 +133,7 @@ The report can be loaded on its own (cost-only) or alongside a metrics export. W
 The `ai_credits_used` value in the metrics JSON is handled independently and does not require the billing CSV. It appears in key metrics, the daily overview and chart, and per-user analysis. When both sources are loaded, the user table distinguishes **AI Credits Used** from the metrics export and **Billed AI Credits** / **AI Credit Cost** from the billing report.
 
 #### Reference tables
-The **Reference tables** section mirrors the newer schema with sortable-by-filter tables for:
+The **Reference Tables** page mirrors the newer schema with sortable-by-filter tables for:
 * Daily overview values, including AI Credits used when available
 * Feature, language, model, and IDE breakdowns
 * AI adoption phases
@@ -142,7 +144,7 @@ The **Reference tables** section mirrors the newer schema with sortable-by-filte
 The **AI adoption phases** table includes the v1 meaning for each cohort. Phase classification is based on Copilot surfaces used on at least two days in a rolling 28-day window: **Phase 0 — No cohort**, **Phase 1 — Code first**, **Phase 2 — Agent first**, and **Phase 3 — Multi-agent**.
 
 #### Per-user detail & CSV export
-Click the **User Usage Table** button (enabled when user-level records are present) to view a sortable table of aggregated metrics per user. It now includes:
+The **Users** page is always available in the page navigation. It shows a clear empty state before upload or when the current export/filter set has no user-level records, and otherwise displays a sortable table of aggregated metrics per user. It includes:
 * Interactions, completions, acceptances, acceptance %
 * Active days, chat days, agent days, CLI days, and code review days
 * Adoption phase, cloud agent days, and coding agent days (when those fields are present)
@@ -154,9 +156,10 @@ Click the **User Usage Table** button (enabled when user-level records are prese
 
 You can:
 * Click column headers to sort ascending/descending.
-* Export the current filtered per-user aggregations to CSV via the **Export CSV** button inside the table view.
-* Use existing filters (date range, user search, members only) then open or refresh the table; it always reflects current filters.
-* Click **Back to Dashboard** to return to the charts and reference tables.
+* Search logins live with the search field above the table. This search affects only the Users table, not the Overview, Charts, AI Credits, or Reference Tables pages.
+* Page through 25 users by default, or choose 10, 25, 50, or 100 rows per page.
+* Export every user matching both the global dashboard filters and the table-local search via **Export CSV**. Export includes all matching pages, not just the visible page.
+* Use the global date range, dashboard user filter, and members-only filter to update every page; the Users table refreshes automatically.
 
 Hover any chart element for tooltips. Categories auto‑trim if extremely long to preserve readability.
 

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     </script>
     <title>GitHub Copilot Metrics Analyzer</title>
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='%23f6f8fa'/%3E%3Cpath d='M8 22h4V14H8zm6 0h4V10h-4zm6 0h4V17h-4z' fill='%230969da'/%3E%3C/svg%3E" />
-    <link rel="stylesheet" href="style.css?v=20260710-phase-meanings" />
+    <link rel="stylesheet" href="style.css?v=20260710-unified-header-4" />
 </head>
 <body>
     <svg class="octicon-sprite" aria-hidden="true" focusable="false">
@@ -67,45 +67,51 @@
     </svg>
     <a class="skip-link" href="#mainContent">Skip to dashboard content</a>
     <header class="app-header">
-        <div class="logo-title">
-            <svg class="octicon brand-icon" aria-hidden="true" focusable="false"><use href="#icon-mark-github"></use></svg>
-            <div class="title-stack">
-                <p class="section-kicker header-kicker">Local analytics</p>
-                <h1>GitHub Copilot Metrics Analyzer</h1>
+        <div class="app-header-main">
+            <div class="logo-title">
+                <svg class="octicon brand-icon" aria-hidden="true" focusable="false"><use href="#icon-mark-github"></use></svg>
+                <div class="title-stack">
+                    <p class="section-kicker header-kicker">Local analytics</p>
+                    <h1>GitHub Copilot Metrics Analyzer</h1>
+                </div>
             </div>
+            <nav class="top-nav" aria-label="Primary">
+                <ul class="nav-list">
+                    <li>
+                        <button type="button" id="themeToggle" class="theme-toggle icon-button" aria-label="Switch to dark mode">
+                            <svg class="octicon theme-icon-sun" aria-hidden="true" focusable="false"><use href="#icon-sun"></use></svg>
+                            <svg class="octicon theme-icon-moon" aria-hidden="true" focusable="false"><use href="#icon-moon"></use></svg>
+                        </button>
+                    </li>
+                    <li><a href="https://github.com/abhi-singhs/copilot-metrics-analysis/blob/main/README.md" target="_blank" rel="noopener noreferrer" aria-label="Open usage guide README in new tab" title="Usage guide"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-book"></use></svg><span class="top-nav-label">Usage guide</span></a></li>
+                </ul>
+            </nav>
         </div>
-        <nav class="top-nav" aria-label="Primary">
-            <ul class="nav-list">
-                <li>
-                    <button type="button" id="themeToggle" class="theme-toggle icon-button" aria-label="Switch to dark mode">
-                        <svg class="octicon theme-icon-sun" aria-hidden="true" focusable="false"><use href="#icon-sun"></use></svg>
-                        <svg class="octicon theme-icon-moon" aria-hidden="true" focusable="false"><use href="#icon-moon"></use></svg>
-                    </button>
-                </li>
-                <li><a href="https://github.com/abhi-singhs/copilot-metrics-analysis/blob/main/README.md" target="_blank" rel="noopener noreferrer" aria-label="Open usage guide README in new tab"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-book"></use></svg>Usage guide</a></li>
+        <nav class="page-nav" aria-label="Dashboard pages">
+            <span class="page-nav-label" aria-hidden="true">Pages</span>
+            <ul class="page-nav-list">
+                <li><a href="#overview" data-page-target="overview" aria-current="page"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-graph"></use></svg>Overview</a></li>
+                <li><a href="#charts" data-page-target="charts"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-graph"></use></svg>Charts</a></li>
+                <li data-page-link="credits" hidden><a href="#credits" data-page-target="credits"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-credit-card"></use></svg>AI Credits</a></li>
+                <li><a href="#tables" data-page-target="tables"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-table"></use></svg>Reference tables</a></li>
+                <li><a href="#users" data-page-target="users"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-people"></use></svg>Users</a></li>
             </ul>
+            <button type="button" id="downloadPdfBtn" class="secondary page-nav-download" disabled aria-label="Download dashboard as PDF" title="Download PDF"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-download"></use></svg><span class="page-nav-download-label">Download PDF</span><span class="page-nav-download-label-short" aria-hidden="true">PDF</span></button>
         </nav>
     </header>
     <main id="mainContent" tabindex="-1">
-        <nav class="section-nav" aria-label="Jump to section">
-            <span class="section-nav-label" aria-hidden="true">Jump to</span>
-            <ul class="section-nav-list">
-                <li><a href="#controlsSection"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-filter"></use></svg>Load &amp; filter</a></li>
-                <li><a href="#summarySection"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-graph"></use></svg>Key metrics</a></li>
-                <li data-section-link="chartsSection"><a href="#chartsSection"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-graph"></use></svg>Charts</a></li>
-                <li data-section-link="creditsSection" hidden><a href="#creditsSection"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-credit-card"></use></svg>AI Credits</a></li>
-                <li data-section-link="tablesSection" hidden><a href="#tablesSection"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-table"></use></svg>Reference tables</a></li>
-                <li data-section-link="userUsageSection" hidden><a href="#userUsageSection"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-people"></use></svg>Per-user detail</a></li>
-            </ul>
-        </nav>
         <section id="controlsSection" class="panel controls-panel" role="region" aria-labelledby="controlsHeading">
-            <div class="section-heading section-heading-compact controls-heading">
-                <div class="heading-copy">
-                    <h2 id="controlsHeading" class="panel-title"><svg class="octicon heading-icon" aria-hidden="true" focusable="false"><use href="#icon-upload"></use></svg>Load metrics and filter the view</h2>
+            <details id="controlsDrawer" class="controls-disclosure" open>
+                <summary class="controls-summary">
+                    <span class="controls-summary-copy">
+                        <span id="controlsHeading" class="controls-summary-title" role="heading" aria-level="2"><svg class="octicon heading-icon" aria-hidden="true" focusable="false"><use href="#icon-upload"></use></svg>Load metrics and filter the view</span>
+                        <span id="controlsSummaryText" class="controls-summary-text">No metrics loaded. Open the controls to upload an export.</span>
+                    </span>
+                    <span class="controls-summary-action" aria-hidden="true"></span>
+                </summary>
+                <div class="controls-drawer-body">
                     <p class="panel-intro">Upload a metrics export, then filter or export the current view. Everything stays in your browser.</p>
-                </div>
-            </div>
-            <form id="filtersForm" class="filters-form" novalidate>
+                    <form id="filtersForm" class="filters-form" novalidate>
                 <fieldset class="control-surface control-surface-main data-group">
                     <legend class="legend-title solo">Controls</legend>
                     <div class="control-toolbar">
@@ -161,8 +167,8 @@
                         <div class="toolbar-side">
                             <div class="toolbar-filters">
                                 <div class="control-item toolbar-item toolbar-search">
-                                    <label for="userSearch">User search</label>
-                                    <input type="text" id="userSearch" placeholder="Filter by login" />
+                                    <label for="userSearch">Dashboard user filter</label>
+                                    <input type="text" id="userSearch" placeholder="Filter every page by login" />
                                 </div>
                                 <div class="control-item toolbar-item toolbar-toggle">
                                     <label class="inline-checkbox" for="membersOnlyChk">
@@ -174,8 +180,6 @@
                             <div class="actions-row actions-row-compact" role="group" aria-label="Dashboard actions">
                                 <button type="button" id="applyFiltersBtn" class="secondary" disabled aria-label="Apply current filters"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-filter"></use></svg>Apply</button>
                                 <button type="button" id="resetFiltersBtn" class="secondary"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-sync"></use></svg>Reset</button>
-                                <button type="button" id="downloadPdfBtn" class="secondary" disabled aria-label="Download dashboard as PDF"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-download"></use></svg>Download PDF</button>
-                                <button type="button" id="userUsageBtn" class="secondary" disabled aria-label="View per-user detail table"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-table"></use></svg>User table</button>
                                 <button type="button" id="clearDataBtn" class="secondary danger-action" disabled aria-label="Clear all loaded data and reset the dashboard"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-trash"></use></svg>Clear</button>
                             </div>
                             <div class="side-details">
@@ -231,11 +235,13 @@
                         </div>
                     </div>
                 </fieldset>
-            </form>
+                    </form>
+                </div>
+            </details>
             <div id="statusMessage" class="status" role="status" aria-live="polite" aria-atomic="true" tabindex="-1"></div>
         </section>
 
-        <section id="summarySection" class="panel metrics-panel" role="region" aria-labelledby="summaryHeading">
+        <section id="summarySection" class="panel metrics-panel page-panel is-active" data-page="overview" role="region" aria-labelledby="summaryHeading" aria-hidden="false" tabindex="-1">
             <div class="section-heading section-heading-compact">
                 <div>
                     <p class="section-kicker">Overview</p>
@@ -246,7 +252,7 @@
             <div id="summaryMetrics" class="metrics-grid" aria-live="polite"></div>
         </section>
 
-        <section id="chartsSection" class="panel charts-panel" role="region" aria-labelledby="chartsHeading" tabindex="-1">
+        <section id="chartsSection" class="panel charts-panel page-panel" data-page="charts" role="region" aria-labelledby="chartsHeading" aria-hidden="true" tabindex="-1" hidden>
             <div class="section-heading section-heading-compact">
                 <div>
                     <p class="section-kicker">Analysis</p>
@@ -257,7 +263,7 @@
             <div id="chartsContainer" class="charts-grid" aria-live="polite"></div>
         </section>
 
-        <section id="creditsSection" class="panel charts-panel" role="region" aria-labelledby="creditsHeading" tabindex="-1" hidden>
+        <section id="creditsSection" class="panel charts-panel page-panel" data-page="credits" role="region" aria-labelledby="creditsHeading" aria-hidden="true" tabindex="-1" hidden>
             <div class="section-heading section-heading-compact">
                 <div>
                     <p class="section-kicker">Cost</p>
@@ -270,7 +276,7 @@
             <div id="creditsTables" class="table-blocks" aria-live="polite"></div>
         </section>
 
-        <section id="tablesSection" class="panel tables-panel" role="region" aria-labelledby="tablesHeading" hidden>
+        <section id="tablesSection" class="panel tables-panel page-panel" data-page="tables" role="region" aria-labelledby="tablesHeading" aria-hidden="true" tabindex="-1" hidden>
             <div class="section-heading section-heading-compact">
                 <div>
                     <p class="section-kicker">Reference</p>
@@ -281,7 +287,7 @@
             <div id="tablesContainer" class="table-blocks" aria-live="polite"></div>
         </section>
 
-        <section id="userUsageSection" class="panel" role="region" aria-labelledby="userUsageHeading" tabindex="-1" hidden>
+        <section id="userUsageSection" class="panel page-panel" data-page="users" role="region" aria-labelledby="userUsageHeading" aria-hidden="true" tabindex="-1" hidden>
             <div class="user-usage-header">
                 <div>
                     <p class="section-kicker">Per-user view</p>
@@ -289,16 +295,41 @@
                 </div>
                 <div class="user-usage-actions">
                     <button type="button" id="exportUsersCsvBtn" class="secondary" disabled aria-label="Export per-user usage as CSV"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-download"></use></svg>Export CSV</button>
-                    <button type="button" id="backToDashboardBtn" class="secondary" aria-label="Return to charts dashboard"><svg class="octicon" aria-hidden="true" focusable="false"><use href="#icon-graph"></use></svg>Back to overview</button>
                 </div>
             </div>
-            <p class="small-note" id="userUsageNote">Aggregated user-level metrics based on the current filters, including AI Credits used, activity flags, CLI usage, and richer LoC totals when the export contains user records. Use the column buttons to sort the table.</p>
+            <p class="small-note" id="userUsageNote">Aggregated user-level metrics based on the global filters. Search this table independently, sort with the column buttons, and export every matching user across all pages.</p>
+            <div class="user-table-toolbar">
+                <div class="control-item user-table-search-control">
+                    <label for="userTableSearch">Search users in this table</label>
+                    <input type="search" id="userTableSearch" placeholder="Search by login" autocomplete="off" />
+                </div>
+                <div class="user-table-toolbar-meta">
+                    <span id="userTableResultCount" class="small-note" aria-live="polite">0 users</span>
+                    <label class="page-size-control" for="userTablePageSize">
+                        <span>Rows per page</span>
+                        <select id="userTablePageSize">
+                            <option value="10">10</option>
+                            <option value="25" selected>25</option>
+                            <option value="50">50</option>
+                            <option value="100">100</option>
+                        </select>
+                    </label>
+                </div>
+            </div>
             <div class="user-table-wrapper" tabindex="0">
-                <table id="userUsageTable" class="usage-table" aria-describedby="userUsageNote">
+                <table id="userUsageTable" class="usage-table" aria-describedby="userUsageNote userTableResultCount">
                     <thead></thead>
                     <tbody></tbody>
                 </table>
             </div>
+            <nav class="user-table-pagination" aria-label="User table pagination">
+                <span id="userTablePageRange" class="small-note" aria-live="polite">No users to display</span>
+                <div class="pagination-actions">
+                    <button type="button" id="userTablePrevBtn" class="secondary" disabled>Previous</button>
+                    <span id="userTablePageStatus" class="pagination-status" aria-live="polite">Page 1 of 1</span>
+                    <button type="button" id="userTableNextBtn" class="secondary" disabled>Next</button>
+                </div>
+            </nav>
         </section>
     </main>
 
@@ -326,6 +357,6 @@
     <!-- Libraries for enhanced PDF export -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" integrity="sha512-BNaRQnYJYiPSqHHDb58B0yaPfCu+Wgds8Gp/gU33kqBtgNS4tSPHuGibyoeqMV/TJlSKda6FXzoEyYGjTe+vXA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/3.0.2/jspdf.umd.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="script.js?v=20260710-phase-meanings"></script>
+    <script src="script.js?v=20260710-no-page-scroll-2"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,13 @@
 // Initialize theme and placeholders; user must upload a file now (no default data.json)
 const THEME_STORAGE_KEY = 'copilotMetricsTheme';
+const DASHBOARD_PAGES = Object.freeze({
+    overview: 'summarySection',
+    charts: 'chartsSection',
+    credits: 'creditsSection',
+    tables: 'tablesSection',
+    users: 'userUsageSection'
+});
+let activeDashboardPage = 'overview';
 
 window.addEventListener('load', () => {
     syncThemeDocumentState(getPreferredTheme());
@@ -7,6 +15,7 @@ window.addEventListener('load', () => {
     updateThemeToggleState(getCurrentTheme());
     setStatus('Ready for a metrics export. Upload a JSON or JSON Lines file to populate the dashboard.');
     renderPlaceholders();
+    syncControlsSummary();
     warnIfFileOrigin();
 });
 
@@ -131,7 +140,8 @@ function refreshThemeCharts() {
     setupHighchartsTheme();
     const activeData = Array.isArray(window.__currentFilteredData) ? window.__currentFilteredData : [];
     if (activeData.length && window.__dashboardModel) {
-        renderCharts(window.__dashboardModel);
+        withDashboardPageMeasurable('charts', () => renderCharts(window.__dashboardModel));
+        updateCreditsView();
     }
 }
 
@@ -299,22 +309,12 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    // Per-user usage view navigation & export
-    const userUsageBtn = document.getElementById('userUsageBtn');
-    const backBtn = document.getElementById('backToDashboardBtn');
+    // Per-user table controls & export
     const exportUsersCsvBtn = document.getElementById('exportUsersCsvBtn');
-    if (userUsageBtn) {
-        userUsageBtn.addEventListener('click', () => {
-            buildUserUsageTable(window.__currentFilteredData || window.__rawData || []);
-            toggleUserUsage(true);
-        });
-    }
-    if (backBtn) {
-        backBtn.addEventListener('click', () => toggleUserUsage(false));
-    }
     if (exportUsersCsvBtn) {
         exportUsersCsvBtn.addEventListener('click', () => exportUserUsageCsv());
     }
+    initializeUserUsageControls();
 
     const clearDataBtn = document.getElementById('clearDataBtn');
     if (clearDataBtn) {
@@ -322,8 +322,9 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     initializeHeaderHeightVar();
-    initializeSectionNav();
+    initializePageNavigation();
     initializeBackToTop();
+    syncControlsSummary();
 });
 
 function initializeHeaderHeightVar() {
@@ -340,40 +341,163 @@ function initializeHeaderHeightVar() {
     }
 }
 
-function initializeSectionNav() {
-    const nav = document.querySelector('.section-nav');
+function initializePageNavigation() {
+    const nav = document.querySelector('.page-nav');
     if (!nav) return;
 
-    // Smooth-scroll to the target section and move focus for accessibility.
     nav.addEventListener('click', (e) => {
-        const link = e.target.closest('a[href^="#"]');
+        const link = e.target.closest('a[data-page-target]');
         if (!link) return;
-        const id = link.getAttribute('href').slice(1);
-        const target = document.getElementById(id);
-        if (!target) return;
         e.preventDefault();
-        target.scrollIntoView({ behavior: preferredScrollBehavior(), block: 'start' });
-        if (!target.hasAttribute('tabindex')) target.setAttribute('tabindex', '-1');
-        target.focus({ preventScroll: true });
-        if (window.history && typeof window.history.replaceState === 'function') {
-            window.history.replaceState(null, '', '#' + id);
-        }
+        setDashboardPage(link.dataset.pageTarget, {
+            focus: false,
+            historyMode: 'push',
+            scroll: false
+        });
     });
 
-    // Keep each jump link in sync with its section's visibility.
-    const toggleable = ['chartsSection', 'creditsSection', 'tablesSection', 'userUsageSection'];
-    const sync = (sectionId) => {
-        const li = nav.querySelector('li[data-section-link="' + sectionId + '"]');
-        const section = document.getElementById(sectionId);
-        if (li && section) li.hidden = !!section.hidden;
-    };
-    toggleable.forEach((sectionId) => {
+    window.addEventListener('popstate', () => {
+        setDashboardPage(getDashboardPageFromHash(), {
+            focus: false,
+            historyMode: null,
+            scroll: false
+        });
+    });
+
+    updateDashboardPageAvailability();
+    setDashboardPage(getDashboardPageFromHash(), {
+        focus: false,
+        historyMode: 'replace',
+        scroll: false
+    });
+}
+
+function getDashboardPageFromHash() {
+    const page = window.location.hash.replace(/^#/, '');
+    return Object.prototype.hasOwnProperty.call(DASHBOARD_PAGES, page) ? page : 'overview';
+}
+
+function isDashboardPageAvailable(page) {
+    return page !== 'credits' || Boolean(window.__hasCredits);
+}
+
+function updateDashboardPageAvailability() {
+    const creditsLink = document.querySelector('[data-page-link="credits"]');
+    if (creditsLink) creditsLink.hidden = !isDashboardPageAvailable('credits');
+    if (!isDashboardPageAvailable(activeDashboardPage)) {
+        setDashboardPage('overview', {
+            focus: false,
+            historyMode: 'replace',
+            scroll: false
+        });
+    }
+}
+
+function setDashboardPage(page, {
+    focus = true,
+    historyMode = null,
+    scroll = true
+} = {}) {
+    const resolvedPage = Object.prototype.hasOwnProperty.call(DASHBOARD_PAGES, page) && isDashboardPageAvailable(page)
+        ? page
+        : 'overview';
+    activeDashboardPage = resolvedPage;
+
+    Object.entries(DASHBOARD_PAGES).forEach(([pageName, sectionId]) => {
         const section = document.getElementById(sectionId);
         if (!section) return;
-        sync(sectionId);
-        new MutationObserver(() => sync(sectionId))
-            .observe(section, { attributes: true, attributeFilter: ['hidden'] });
+        const isActive = pageName === resolvedPage;
+        section.hidden = !isActive;
+        section.classList.toggle('is-active', isActive);
+        section.setAttribute('aria-hidden', String(!isActive));
+        if ('inert' in section) section.inert = !isActive;
     });
+
+    document.querySelectorAll('.page-nav a[data-page-target]').forEach(link => {
+        const isActive = link.dataset.pageTarget === resolvedPage;
+        if (isActive) link.setAttribute('aria-current', 'page');
+        else link.removeAttribute('aria-current');
+    });
+
+    const target = document.getElementById(DASHBOARD_PAGES[resolvedPage]);
+    if (resolvedPage === 'charts' || resolvedPage === 'credits') {
+        window.requestAnimationFrame(() => reflowChartsWithin(target));
+    }
+    if (scroll && target) {
+        target.scrollIntoView({ behavior: preferredScrollBehavior(), block: 'start' });
+    }
+    if (focus && target) {
+        target.focus({ preventScroll: true });
+    }
+
+    const hash = '#' + resolvedPage;
+    if (historyMode && window.history && window.location.hash !== hash) {
+        const method = historyMode === 'push' ? 'pushState' : 'replaceState';
+        window.history[method](null, '', hash);
+    }
+}
+
+function withDashboardPageMeasurable(page, callback) {
+    const section = document.getElementById(DASHBOARD_PAGES[page]);
+    if (!section || !section.hidden) return callback();
+
+    section.hidden = false;
+    section.classList.add('page-rendering');
+    try {
+        return callback();
+    } finally {
+        section.classList.remove('page-rendering');
+        section.hidden = true;
+    }
+}
+
+function reflowChartsWithin(container) {
+    if (!container || typeof Highcharts === 'undefined') return;
+    Highcharts.charts.forEach(chart => {
+        if (chart && chart.renderTo && container.contains(chart.renderTo)) chart.reflow();
+    });
+}
+
+function setControlsDrawerOpen(open) {
+    const drawer = document.getElementById('controlsDrawer');
+    if (drawer) drawer.open = Boolean(open);
+}
+
+function syncControlsSummary() {
+    const summary = document.getElementById('controlsSummaryText');
+    if (!summary) return;
+    const rawCount = Array.isArray(window.__rawData) ? window.__rawData.length : 0;
+    const creditCount = Array.isArray(window.__aiCreditsRaw) ? window.__aiCreditsRaw.length : 0;
+    if (!rawCount) {
+        summary.textContent = creditCount
+            ? `${creditCount.toLocaleString()} AI Credit rows loaded. Open the controls to add a metrics export or change filters.`
+            : 'No metrics loaded. Open the controls to upload an export.';
+        return;
+    }
+
+    const filteredCount = Array.isArray(window.__currentFilteredData)
+        ? window.__currentFilteredData.length
+        : rawCount;
+    const state = getActiveFilterState();
+    const fileName = window.__metricsFileName || 'Metrics export';
+    const parts = [
+        fileName,
+        `${filteredCount.toLocaleString()} of ${rawCount.toLocaleString()} records`
+    ];
+    if (state.from || state.to) parts.push(`${state.from || 'start'} to ${state.to || 'latest'}`);
+    if (state.search) parts.push(`user contains "${state.search}"`);
+    if (state.membersOnly) parts.push('members only');
+    summary.textContent = parts.join(' · ');
+}
+
+function expandControlsForError() {
+    setControlsDrawerOpen(true);
+    syncControlsSummary();
+}
+
+function collapseControlsAfterLoad() {
+    syncControlsSummary();
+    setControlsDrawerOpen(false);
 }
 
 function initializeBackToTop() {
@@ -406,6 +530,7 @@ function syncSelectedFileName(inputEl, outputId, emptyText = 'No file chosen') {
     const fileName = inputEl.files && inputEl.files[0] ? inputEl.files[0].name : emptyText;
     outputEl.textContent = fileName;
     outputEl.title = fileName;
+    syncControlsSummary();
 }
 
 function syncAiCreditsReportUploadVisibility() {
@@ -501,7 +626,11 @@ function parseUploadedText(text) {
 }
 
 function handleFileSelection(file) {
-    if (!file) { setStatus('No file selected. Please choose a JSON / JSONL export file.'); return; }
+    if (!file) {
+        expandControlsForError();
+        setStatus('No file selected. Please choose a JSON / JSONL export file.');
+        return;
+    }
     showLoading(true);
     setStatus(`Reading ${file.name} …`);
     const reader = new FileReader();
@@ -515,18 +644,31 @@ function handleFileSelection(file) {
             }
             window.__sourceData = data;
             window.__rawData = normalized;
+            window.__metricsFileName = file.name;
+            resetUserUsageTableState({ clearQuery: true, resetPreferences: true });
             initializeFilters(normalized);
             analyzeData(normalized);
             setStatus(`Loaded ${normalized.length} usable records from ${file.name}`);
             enableDownloadButton();
+            setDashboardPage('overview', {
+                focus: false,
+                historyMode: 'replace',
+                scroll: false
+            });
+            collapseControlsAfterLoad();
         } catch (err) {
             console.error(err);
+            expandControlsForError();
             setStatus(`Upload parse error: ${err.message}`, true);
         } finally {
             showLoading(false);
         }
     };
-    reader.onerror = () => { setStatus('File read error', true); showLoading(false); };
+    reader.onerror = () => {
+        expandControlsForError();
+        setStatus('File read error', true);
+        showLoading(false);
+    };
     reader.readAsText(file);
 }
 
@@ -651,14 +793,24 @@ function loadDataFile(filename) {
                 const normalized = normalizeUsageRecords(data);
                 window.__sourceData = data;
                 window.__rawData = normalized;
+                window.__metricsFileName = filename;
+                resetUserUsageTableState({ clearQuery: true, resetPreferences: true });
                 initializeFilters(normalized);
                 analyzeData(normalized);
                 enableDownloadButton();
+                setDashboardPage('overview', {
+                    focus: false,
+                    historyMode: 'replace',
+                    scroll: false
+                });
+                collapseControlsAfterLoad();
             } catch (error) {
+                expandControlsForError();
                 setStatus(`Parse error: ${error.message}`, true);
             }
         })
         .catch(error => {
+            expandControlsForError();
             setStatus(`Load error: ${error.message}`, true);
         })
         .finally(() => {
@@ -669,6 +821,7 @@ function loadDataFile(filename) {
 function analyzeData(data) {
     const chartsContainer = document.getElementById('chartsContainer');
     if (chartsContainer) chartsContainer.innerHTML = '';
+    window.__currentFilteredData = Array.isArray(data) ? data : [];
 
     if (!data || data.length === 0) {
         const hasLoadedData = Boolean(window.__rawData && window.__rawData.length);
@@ -680,15 +833,12 @@ function analyzeData(data) {
                     ? 'AI Credits report loaded. Upload a usage-metrics JSON/JSONL file to combine credit cost with engagement metrics.'
                     : 'Ready for a metrics export. Upload a JSON or JSON Lines file to populate the dashboard.')
         );
-        const tablesSection = document.getElementById('tablesSection');
-        if (tablesSection) tablesSection.hidden = true;
         renderPlaceholders(hasLoadedData ? 'filters' : 'upload');
         const downloadBtn = document.getElementById('downloadPdfBtn');
         if (downloadBtn) downloadBtn.disabled = true;
-        const userUsageBtn = document.getElementById('userUsageBtn');
-        if (userUsageBtn) userUsageBtn.disabled = true;
         updateClearButtonState();
         updateCreditsView();
+        syncControlsSummary();
         return;
     }
 
@@ -697,23 +847,18 @@ function analyzeData(data) {
     window.__currentFilteredData = data;
 
     computeSummaryMetrics(model);
-    renderCharts(model);
+    withDashboardPageMeasurable('charts', () => renderCharts(model));
     renderReferenceTables(model);
     updateCreditsView();
+    buildUserUsageTable(data);
     enableDownloadButton();
     updateClearButtonState();
-
-    const userUsageBtn = document.getElementById('userUsageBtn');
-    if (userUsageBtn) userUsageBtn.disabled = !model.meta.hasUserRecords;
-    if (!model.meta.hasUserRecords) {
-        const userUsageSection = document.getElementById('userUsageSection');
-        if (userUsageSection && !userUsageSection.hidden) toggleUserUsage(false);
-    }
 
     const scopeLabel = model.meta.hasAggregateRecords
         ? (model.meta.hasUserRecords ? 'mixed export' : 'aggregate export')
         : 'user export';
     setStatus(`Displaying ${model.meta.recordCount.toLocaleString()} records across ${model.meta.days.length.toLocaleString()} days (${scopeLabel})`);
+    syncControlsSummary();
 
     const main = document.getElementById('mainContent');
     if (main) {
@@ -1329,9 +1474,8 @@ function renderCharts(model) {
 }
 
 function renderReferenceTables(model) {
-    const section = document.getElementById('tablesSection');
     const container = document.getElementById('tablesContainer');
-    if (!section || !container) return;
+    if (!container) return;
 
     const blocks = [];
     const dailyRows = [...model.breakdowns.dailyRows].reverse();
@@ -1512,13 +1656,25 @@ function renderReferenceTables(model) {
     }
 
     if (!blocks.length) {
-        section.hidden = true;
-        container.innerHTML = '';
+        renderReferenceTablesEmpty('filters');
         return;
     }
 
-    section.hidden = false;
     container.innerHTML = blocks.join('');
+}
+
+function renderReferenceTablesEmpty(mode = 'upload') {
+    const container = document.getElementById('tablesContainer');
+    if (!container) return;
+    const hasFilteredData = mode === 'filters';
+    const title = hasFilteredData ? 'No reference tables match these filters' : 'Reference tables appear after upload';
+    const description = hasFilteredData
+        ? 'Widen the global filters to restore daily and breakdown tables.'
+        : 'Load a metrics export to inspect exact daily, feature, model, language, IDE, and activity values.';
+    container.innerHTML = `<div class="page-empty-state" role="note">
+        <h3>${escapeHtml(title)}</h3>
+        <p>${escapeHtml(description)}</p>
+    </div>`;
 }
 
 function renderTableBlock(title, note, columns, rows, open = false) {
@@ -2029,13 +2185,9 @@ function applyFilters() {
     if (membersOnly && window.__membersSet) {
         filtered = filtered.filter(r => window.__membersSet.has((r.user_login || '').toLowerCase()));
     }
-    analyzeData(filtered);
-    // Cache for user usage table & update if visible
     window.__currentFilteredData = filtered;
-    const userUsageSection = document.getElementById('userUsageSection');
-    if (userUsageSection && !userUsageSection.hidden) {
-        buildUserUsageTable(filtered);
-    }
+    analyzeData(filtered);
+    syncControlsSummary();
 }
 
 function enableApplyButton() {
@@ -2170,6 +2322,7 @@ function setStatus(msg, isError=false) {
     el.setAttribute('aria-live', isError ? 'assertive' : 'polite');
     el.setAttribute('aria-atomic', 'true');
     window.__statusMessage = { text: msg, error: !!isError };
+    syncControlsSummary();
 }
 
 function showLoading(show) {
@@ -2184,8 +2337,6 @@ function showLoading(show) {
 function enableDownloadButton() {
     const btn = document.getElementById('downloadPdfBtn');
     if (btn) btn.disabled = false;
-    const uBtn = document.getElementById('userUsageBtn');
-    if (uBtn) uBtn.disabled = !(window.__dashboardModel && window.__dashboardModel.meta.hasUserRecords);
 }
 
 function updateClearButtonState() {
@@ -2206,6 +2357,10 @@ function clearAllData() {
     window.__membersSet = null;
     window.__allDays = [];
     window.__hasCredits = false;
+    window.__metricsFileName = null;
+    window.__userUsageRows = null;
+    window.__userUsageColumns = null;
+    resetUserUsageTableState({ clearQuery: true, resetPreferences: true });
 
     // Reset the file inputs and their displayed names.
     ['jsonFileInput', 'aiCreditsFileInput', 'membersFileInput'].forEach(id => {
@@ -2233,32 +2388,22 @@ function clearAllData() {
     });
     updateMembersStatus();
 
-    // Return to the dashboard view and clear rendered content.
-    const userUsageSection = document.getElementById('userUsageSection');
-    if (userUsageSection) userUsageSection.hidden = true;
-    const chartsSection = document.getElementById('chartsSection');
-    if (chartsSection) chartsSection.hidden = false;
-    const userTable = document.getElementById('userUsageTable');
-    if (userTable) {
-        const thead = userTable.querySelector('thead');
-        const tbody = userTable.querySelector('tbody');
-        if (thead) thead.innerHTML = '';
-        if (tbody) tbody.innerHTML = '';
-    }
-    const tablesContainer = document.getElementById('tablesContainer');
-    if (tablesContainer) tablesContainer.innerHTML = '';
-    const tablesSection = document.getElementById('tablesSection');
-    if (tablesSection) tablesSection.hidden = true;
-    updateCreditsView(); // no credits -> hides and clears the cost section
+    updateCreditsView();
+    setDashboardPage('overview', {
+        focus: false,
+        historyMode: 'replace',
+        scroll: false
+    });
 
     // Disable the data-dependent actions.
-    ['applyFiltersBtn', 'downloadPdfBtn', 'userUsageBtn', 'exportUsersCsvBtn', 'clearDataBtn'].forEach(id => {
+    ['applyFiltersBtn', 'downloadPdfBtn', 'exportUsersCsvBtn', 'clearDataBtn'].forEach(id => {
         const btn = document.getElementById(id);
         if (btn) btn.disabled = true;
     });
 
     // Restore the initial empty state.
     renderPlaceholders('upload');
+    setControlsDrawerOpen(true);
     setStatus('Cleared all loaded data. Upload a JSON or JSON Lines file to populate the dashboard.');
 
     // Send the user back to the top and refocus the metrics file picker.
@@ -2371,6 +2516,8 @@ function renderPlaceholders(mode = 'upload') {
     if (metrics) metrics.innerHTML = buildMetricPlaceholders(mode);
     const charts = document.getElementById('chartsContainer');
     if (charts) charts.innerHTML = buildChartPlaceholders(mode);
+    renderReferenceTablesEmpty(mode);
+    buildUserUsageTable([]);
 }
 
 // --- Enhanced PDF generation (multi-page) ---
@@ -2621,24 +2768,64 @@ async function generatePdfReport() {
 }
 
 // ================= Per-User Usage Table & CSV Export ================= //
-let userUsageSort = { key: 'user_login', dir: 'asc' };
+const userUsageTableState = {
+    sortKey: 'user_login',
+    sortDir: 'asc',
+    query: '',
+    page: 1,
+    pageSize: 25
+};
 
-function toggleUserUsage(show) {
-    const section = document.getElementById('userUsageSection');
-    const chartsSec = document.getElementById('chartsSection');
-    if (!section || !chartsSec) return;
-    section.hidden = !show;
-    chartsSec.hidden = show;
-    const creditsSec = document.getElementById('creditsSection');
-    if (creditsSec && window.__hasCredits) creditsSec.hidden = show;
-    if (show) {
-        section.scrollIntoView({ behavior: preferredScrollBehavior(), block: 'start' });
-        document.getElementById('exportUsersCsvBtn')?.removeAttribute('disabled');
-        section.focus({ preventScroll: true });
-    } else {
-        chartsSec.scrollIntoView({ behavior: preferredScrollBehavior(), block: 'start' });
-        chartsSec.focus({ preventScroll: true });
+function initializeUserUsageControls() {
+    const search = document.getElementById('userTableSearch');
+    const pageSize = document.getElementById('userTablePageSize');
+    const previous = document.getElementById('userTablePrevBtn');
+    const next = document.getElementById('userTableNextBtn');
+
+    if (search) {
+        search.addEventListener('input', () => {
+            userUsageTableState.query = search.value.trim().toLowerCase();
+            userUsageTableState.page = 1;
+            renderUserUsageRows();
+        });
     }
+    if (pageSize) {
+        pageSize.addEventListener('change', () => {
+            const selectedSize = Number(pageSize.value);
+            userUsageTableState.pageSize = [10, 25, 50, 100].includes(selectedSize) ? selectedSize : 25;
+            userUsageTableState.page = 1;
+            renderUserUsageRows();
+        });
+    }
+    if (previous) {
+        previous.addEventListener('click', () => {
+            if (userUsageTableState.page <= 1) return;
+            userUsageTableState.page -= 1;
+            renderUserUsageRows();
+        });
+    }
+    if (next) {
+        next.addEventListener('click', () => {
+            userUsageTableState.page += 1;
+            renderUserUsageRows();
+        });
+    }
+}
+
+function resetUserUsageTableState({ clearQuery = false, resetPreferences = false } = {}) {
+    userUsageTableState.page = 1;
+    if (resetPreferences) {
+        userUsageTableState.sortKey = 'user_login';
+        userUsageTableState.sortDir = 'asc';
+        userUsageTableState.pageSize = 25;
+    }
+    if (clearQuery) {
+        userUsageTableState.query = '';
+        const search = document.getElementById('userTableSearch');
+        if (search) search.value = '';
+    }
+    const pageSize = document.getElementById('userTablePageSize');
+    if (pageSize) pageSize.value = String(userUsageTableState.pageSize);
 }
 
 function aggregateUserUsage(data, creditsByUser) {
@@ -2837,21 +3024,14 @@ function buildUserUsageTable(data) {
     const table = document.getElementById('userUsageTable');
     if (!table) return;
     const thead = table.querySelector('thead');
-    const tbody = table.querySelector('tbody');
     const creditsByUser = creditsByUserIndex(filterCreditRows(window.__aiCreditsRaw || [], getActiveFilterState()));
     const rows = aggregateUserUsage(data, creditsByUser);
     window.__userUsageRows = rows;
     const columns = buildUserUsageColumns();
     window.__userUsageColumns = columns;
-    const exportBtn = document.getElementById('exportUsersCsvBtn');
-    // Build head
+    userUsageTableState.page = 1;
+
     thead.innerHTML = '';
-    if (!rows.length) {
-        if (exportBtn) exportBtn.disabled = true;
-        tbody.innerHTML = `<tr><td colspan="${columns.length}">No user-level records are available for the current filters.</td></tr>`;
-        return;
-    }
-    if (exportBtn) exportBtn.disabled = false;
     const tr = document.createElement('tr');
     columns.forEach(h => {
         const th = document.createElement('th');
@@ -2859,18 +3039,22 @@ function buildUserUsageTable(data) {
         th.dataset.label = h.label;
         th.scope = 'col';
         th.classList.add('sortable');
-        th.setAttribute('aria-sort', h.key === userUsageSort.key ? (userUsageSort.dir === 'asc' ? 'ascending' : 'descending') : 'none');
+        th.setAttribute('aria-sort', h.key === userUsageTableState.sortKey
+            ? (userUsageTableState.sortDir === 'asc' ? 'ascending' : 'descending')
+            : 'none');
         const sortBtn = document.createElement('button');
         sortBtn.type = 'button';
         sortBtn.className = 'sort-button';
         sortBtn.textContent = h.label;
         sortBtn.setAttribute('aria-label', `Sort by ${h.label}`);
         sortBtn.addEventListener('click', () => {
-            if (userUsageSort.key === h.key) {
-                userUsageSort.dir = userUsageSort.dir === 'asc' ? 'desc' : 'asc';
+            if (userUsageTableState.sortKey === h.key) {
+                userUsageTableState.sortDir = userUsageTableState.sortDir === 'asc' ? 'desc' : 'asc';
             } else {
-                userUsageSort.key = h.key; userUsageSort.dir = 'asc';
+                userUsageTableState.sortKey = h.key;
+                userUsageTableState.sortDir = 'asc';
             }
+            userUsageTableState.page = 1;
             renderUserUsageRows();
         });
         th.appendChild(sortBtn);
@@ -2878,35 +3062,103 @@ function buildUserUsageTable(data) {
     });
     thead.appendChild(tr);
     renderUserUsageRows();
+}
 
-    function renderUserUsageRows() {
-        const key = userUsageSort.key; const dir = userUsageSort.dir === 'asc' ? 1 : -1;
-        rows.sort((a,b) => {
-            const va = a[key]; const vb = b[key];
-            if (typeof va === 'number' && typeof vb === 'number') return (va - vb) * dir;
-            return String(va ?? '').localeCompare(String(vb ?? ''), undefined, { sensitivity: 'base' }) * dir;
-        });
-        tbody.innerHTML = rows.map(r => '<tr>' + columns.map(col => {
+function getFilteredAndSortedUserUsageRows(rows = window.__userUsageRows || []) {
+    const query = userUsageTableState.query;
+    const filtered = query
+        ? rows.filter(row => String(row.user_login || '').toLowerCase().includes(query))
+        : [...rows];
+    const key = userUsageTableState.sortKey;
+    const direction = userUsageTableState.sortDir === 'asc' ? 1 : -1;
+    return filtered.sort((a, b) => {
+        const aValue = a[key];
+        const bValue = b[key];
+        if (typeof aValue === 'number' && typeof bValue === 'number') {
+            return (aValue - bValue) * direction;
+        }
+        return String(aValue ?? '').localeCompare(
+            String(bValue ?? ''),
+            undefined,
+            { sensitivity: 'base' }
+        ) * direction;
+    });
+}
+
+function renderUserUsageRows() {
+    const table = document.getElementById('userUsageTable');
+    if (!table) return;
+    const thead = table.querySelector('thead');
+    const tbody = table.querySelector('tbody');
+    const rows = window.__userUsageRows || [];
+    const columns = window.__userUsageColumns || buildUserUsageColumns();
+    const matchingRows = getFilteredAndSortedUserUsageRows(rows);
+    const pageSize = userUsageTableState.pageSize;
+    const pageCount = Math.max(1, Math.ceil(matchingRows.length / pageSize));
+    userUsageTableState.page = Math.min(Math.max(1, userUsageTableState.page), pageCount);
+    const startIndex = (userUsageTableState.page - 1) * pageSize;
+    const pageRows = matchingRows.slice(startIndex, startIndex + pageSize);
+
+    if (pageRows.length) {
+        tbody.innerHTML = pageRows.map(r => '<tr>' + columns.map(col => {
             const cell = renderUserUsageCell(col, r);
             return col.rowHeader ? `<th scope="row">${cell}</th>` : `<td>${cell}</td>`;
         }).join('') + '</tr>').join('');
-        thead.querySelectorAll('th.sortable').forEach(th => {
-            const isActive = th.dataset.key === key;
-            const label = th.dataset.label || th.dataset.key;
-            th.setAttribute('aria-sort', isActive ? (dir === 1 ? 'ascending' : 'descending') : 'none');
-            th.classList.toggle('sort-asc', isActive && dir === 1);
-            th.classList.toggle('sort-desc', isActive && dir !== 1);
-            const button = th.querySelector('.sort-button');
-            if (button) {
-                button.setAttribute(
-                    'aria-label',
-                    isActive
-                        ? `${label}, sorted ${dir === 1 ? 'ascending' : 'descending'}. Activate to sort ${dir === 1 ? 'descending' : 'ascending'}.`
-                        : `Sort by ${label}`
-                );
-            }
-        });
+    } else {
+        const emptyMessage = rows.length
+            ? `No users match "${userUsageTableState.query}" in this table.`
+            : 'No user-level records are available for the current global filters.';
+        tbody.innerHTML = `<tr><td class="user-table-empty" colspan="${columns.length}">${escapeHtml(emptyMessage)}</td></tr>`;
     }
+
+    const direction = userUsageTableState.sortDir === 'asc' ? 1 : -1;
+    thead.querySelectorAll('th.sortable').forEach(th => {
+        const isActive = th.dataset.key === userUsageTableState.sortKey;
+        const label = th.dataset.label || th.dataset.key;
+        th.setAttribute('aria-sort', isActive ? (direction === 1 ? 'ascending' : 'descending') : 'none');
+        th.classList.toggle('sort-asc', isActive && direction === 1);
+        th.classList.toggle('sort-desc', isActive && direction !== 1);
+        const button = th.querySelector('.sort-button');
+        if (button) {
+            button.setAttribute(
+                'aria-label',
+                isActive
+                    ? `${label}, sorted ${direction === 1 ? 'ascending' : 'descending'}. Activate to sort ${direction === 1 ? 'descending' : 'ascending'}.`
+                    : `Sort by ${label}`
+            );
+        }
+    });
+
+    const resultCount = document.getElementById('userTableResultCount');
+    if (resultCount) {
+        resultCount.textContent = userUsageTableState.query
+            ? `${matchingRows.length.toLocaleString()} of ${rows.length.toLocaleString()} users`
+            : `${rows.length.toLocaleString()} users`;
+    }
+    const pageRange = document.getElementById('userTablePageRange');
+    if (pageRange) {
+        const first = matchingRows.length ? startIndex + 1 : 0;
+        const last = matchingRows.length ? startIndex + pageRows.length : 0;
+        pageRange.textContent = matchingRows.length
+            ? `Showing ${first.toLocaleString()}–${last.toLocaleString()} of ${matchingRows.length.toLocaleString()} users`
+            : 'No users to display';
+    }
+    const pageStatus = document.getElementById('userTablePageStatus');
+    if (pageStatus) pageStatus.textContent = `Page ${userUsageTableState.page} of ${pageCount}`;
+
+    const previous = document.getElementById('userTablePrevBtn');
+    const next = document.getElementById('userTableNextBtn');
+    const pageSizeSelect = document.getElementById('userTablePageSize');
+    const search = document.getElementById('userTableSearch');
+    const exportBtn = document.getElementById('exportUsersCsvBtn');
+    if (previous) previous.disabled = !matchingRows.length || userUsageTableState.page <= 1;
+    if (next) next.disabled = !matchingRows.length || userUsageTableState.page >= pageCount;
+    if (pageSizeSelect) {
+        pageSizeSelect.value = String(pageSize);
+        pageSizeSelect.disabled = !rows.length;
+    }
+    if (search) search.disabled = !rows.length;
+    if (exportBtn) exportBtn.disabled = !matchingRows.length;
 }
 
 function exportUserUsageCsv() {
@@ -2917,7 +3169,11 @@ function exportUserUsageCsv() {
         rows = aggregateUserUsage(window.__currentFilteredData || window.__rawData || [], creditsByUser);
         columns = buildUserUsageColumns();
     }
-    if (!rows.length) { setStatus('No per-user rows are available to export for the current filters.', true); return; }
+    rows = getFilteredAndSortedUserUsageRows(rows);
+    if (!rows.length) {
+        setStatus('No per-user rows match the current global filters and table search.', true);
+        return;
+    }
     const csvValue = (col, r) => {
         if (col.csv) return col.csv(r);
         const val = r[col.key];
@@ -2947,6 +3203,7 @@ function exportUserUsageCsv() {
     a.href = url; a.download = `copilot-user-usage-${dateStr}.csv`;
     document.body.appendChild(a); a.click(); document.body.removeChild(a);
     URL.revokeObjectURL(url);
+    setStatus(`Exported ${rows.length.toLocaleString()} matching users to CSV.`);
 }
 
 function csvEscape(val) {
@@ -3131,24 +3388,42 @@ function buildCreditsModel(rows) {
     };
 }
 
-function renderAiCreditsSection(cm) {
+function renderAiCreditsSection(cm, hasReport = false) {
     const section = document.getElementById('creditsSection');
     const metricsEl = document.getElementById('creditsMetrics');
     const chartsEl = document.getElementById('creditsCharts');
     const tablesEl = document.getElementById('creditsTables');
     if (!section || !metricsEl || !chartsEl || !tablesEl) return;
 
-    if (!cm || !cm.rows.length) {
+    if (!hasReport) {
         window.__hasCredits = false;
-        section.hidden = true;
         metricsEl.innerHTML = '';
+        chartsEl.innerHTML = '';
+        tablesEl.innerHTML = '';
+        updateDashboardPageAvailability();
+        return;
+    }
+
+    window.__hasCredits = true;
+    updateDashboardPageAvailability();
+    if (!cm || !cm.rows.length) {
+        metricsEl.innerHTML = `<div class="page-empty-state" role="note">
+            <h3>No AI Credit rows match the global filters</h3>
+            <p>Widen the date range, clear the global user filter, or turn off members-only filtering.</p>
+        </div>`;
         chartsEl.innerHTML = '';
         tablesEl.innerHTML = '';
         return;
     }
 
-    window.__hasCredits = true;
-    section.hidden = false;
+    withDashboardPageMeasurable(
+        'credits',
+        () => renderAiCreditsSectionContent(cm, metricsEl, chartsEl, tablesEl)
+    );
+    enableDownloadButton();
+}
+
+function renderAiCreditsSectionContent(cm, metricsEl, chartsEl, tablesEl) {
     const t = cm.totals;
 
     const cards = [
@@ -3250,15 +3525,16 @@ function renderAiCreditsSection(cm) {
         ));
     }
     tablesEl.innerHTML = blocks.join('');
-
-    enableDownloadButton();
 }
 
 function updateCreditsView() {
     const raw = window.__aiCreditsRaw;
-    if (!raw || !raw.length) { renderAiCreditsSection(null); return; }
+    if (!raw || !raw.length) {
+        renderAiCreditsSection(null, false);
+        return;
+    }
     const filtered = filterCreditRows(raw, getActiveFilterState());
-    renderAiCreditsSection(buildCreditsModel(filtered));
+    renderAiCreditsSection(buildCreditsModel(filtered), true);
 }
 
 function refreshDateBoundsUnion() {

--- a/style.css
+++ b/style.css
@@ -197,6 +197,7 @@ body {
 a,
 button,
 input,
+select,
 textarea,
 summary {
     -webkit-tap-highlight-color: transparent;
@@ -226,17 +227,25 @@ header.app-header {
     position: sticky;
     top: 0;
     z-index: 20;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.5rem 1rem;
+    display: grid;
     width: 100%;
     max-width: 1680px;
     margin-inline: auto;
-    padding: 0.75rem;
+    padding: 0;
     background: var(--header-bg);
     border-bottom: 1px solid var(--panel-border);
     box-shadow: none;
+}
+
+.app-header-main {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem 1rem;
+    min-width: 0;
+    width: 100%;
+    padding: 0.65rem 0.75rem;
 }
 
 .logo-title {
@@ -350,6 +359,7 @@ html[data-theme="dark"] .theme-toggle .theme-icon-moon {
 }
 
 main {
+    position: relative;
     max-width: 1680px;
     margin-inline: auto;
     padding: 0.75rem;
@@ -365,7 +375,75 @@ main {
 }
 
 .controls-panel {
+    padding: 0;
+    overflow: hidden;
     background: var(--panel);
+}
+
+.controls-disclosure > summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.72rem 0.85rem;
+    cursor: pointer;
+    list-style: none;
+}
+
+.controls-disclosure > summary::-webkit-details-marker {
+    display: none;
+}
+
+.controls-disclosure[open] > summary {
+    border-bottom: 1px solid var(--panel-border);
+    background: var(--panel-subtle);
+}
+
+.controls-summary-copy {
+    display: grid;
+    gap: 0.18rem;
+    min-width: 0;
+}
+
+.controls-summary-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    color: var(--text);
+    font-size: 1rem;
+    font-weight: 750;
+}
+
+.controls-summary-text {
+    overflow: hidden;
+    color: var(--text-dim);
+    font-size: 0.84rem;
+    line-height: 1.35;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.controls-summary-action {
+    flex: 0 0 auto;
+    color: var(--accent);
+    font-size: 0.82rem;
+    font-weight: 700;
+}
+
+.controls-summary-action::before {
+    content: "Hide controls";
+}
+
+.controls-disclosure:not([open]) .controls-summary-action::before {
+    content: "Show controls";
+}
+
+.controls-drawer-body {
+    padding: 0.75rem;
+}
+
+.controls-drawer-body > .panel-intro {
+    margin: 0 0 0.75rem;
 }
 
 .section-heading {
@@ -652,9 +730,11 @@ fieldset {
 }
 
 input[type="text"],
+input[type="search"],
 input[type="date"],
 input[type="password"],
-textarea {
+textarea,
+select {
     width: 100%;
     min-height: 32px;
     padding: 0.42rem 0.65rem;
@@ -1001,12 +1081,16 @@ button:disabled {
 }
 
 #statusMessage {
-    margin-top: 0.75rem;
+    margin: 0.75rem;
     padding: 0.7rem 0.8rem;
     border: 1px solid transparent;
     border-radius: var(--radius);
     background: var(--panel-subtle);
     color: var(--text-dim);
+}
+
+.controls-disclosure:not([open]) + #statusMessage[data-state="info"] {
+    display: none;
 }
 
 #statusMessage:empty {
@@ -1332,6 +1416,46 @@ button:disabled {
     gap: 0.5rem;
 }
 
+.user-table-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: end;
+    justify-content: space-between;
+    gap: 0.75rem 1rem;
+    margin: 0.8rem 0;
+    padding: 0.7rem;
+    border: 1px solid var(--panel-border);
+    border-radius: var(--radius);
+    background: var(--panel-subtle);
+}
+
+.user-table-search-control {
+    flex: 1 1 260px;
+    max-width: 34rem;
+}
+
+.user-table-toolbar-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.75rem 1rem;
+}
+
+.page-size-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-dim);
+    font-size: 0.84rem;
+    font-weight: 650;
+}
+
+.page-size-control select {
+    width: auto;
+    min-width: 4.5rem;
+}
+
 .usage-table {
     width: 100%;
     border-collapse: separate;
@@ -1399,6 +1523,13 @@ button:disabled {
     font-weight: 700;
 }
 
+.usage-table .user-table-empty {
+    padding: 2rem 1rem;
+    color: var(--text-dim);
+    text-align: center;
+    white-space: normal;
+}
+
 .usage-table th.sortable {
     padding-top: 0.55rem;
     padding-bottom: 0.55rem;
@@ -1441,6 +1572,51 @@ button.sort-button::after {
     content: "\2193";
     color: var(--accent-strong);
     opacity: 1;
+}
+
+.user-table-pagination {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+}
+
+.pagination-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.pagination-status {
+    min-width: 6.5rem;
+    color: var(--text-dim);
+    font-size: 0.84rem;
+    font-weight: 650;
+    text-align: center;
+}
+
+.page-empty-state {
+    grid-column: 1 / -1;
+    padding: clamp(1.2rem, 2.4vw, 2rem);
+    border: 1px dashed var(--panel-border-strong);
+    border-radius: var(--radius);
+    background: var(--panel-subtle);
+    text-align: center;
+}
+
+.page-empty-state h3 {
+    margin: 0;
+    color: var(--text);
+    font-size: 1rem;
+}
+
+.page-empty-state p {
+    margin: 0.4rem auto 0;
+    max-width: 62ch;
+    color: var(--text-dim);
+    font-size: 0.9rem;
 }
 
 .loading-overlay {
@@ -1544,6 +1720,7 @@ code {
 a:focus-visible,
 button:focus-visible,
 input:focus-visible,
+select:focus-visible,
 textarea:focus-visible,
 summary:focus-visible,
 .user-table-wrapper:focus-visible {
@@ -1551,21 +1728,24 @@ summary:focus-visible,
     outline-offset: 2px;
 }
 
-/* ===== Jump-to-section nav ===== */
-.section-nav {
+/* ===== Dashboard page navigation ===== */
+.page-nav {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: 0.35rem 0.5rem;
-    margin: 0 0 0.6rem;
-    padding: 0.45rem 0.55rem;
-    border: 1px solid var(--panel-border);
-    border-radius: var(--radius);
-    background: var(--panel);
+    min-width: 0;
+    width: 100%;
+    margin: 0;
+    padding: 0.42rem 0.75rem;
+    border: 0;
+    border-top: 1px solid var(--panel-border);
+    border-radius: 0;
+    background: transparent;
     box-shadow: none;
 }
 
-.section-nav-label {
+.page-nav-label {
     padding-inline: 0.35rem;
     color: var(--text-soft);
     font-size: 0.72rem;
@@ -1574,16 +1754,28 @@ summary:focus-visible,
     text-transform: uppercase;
 }
 
-.section-nav-list {
+.page-nav-list {
     display: flex;
+    flex: 1 1 auto;
     flex-wrap: wrap;
     gap: 0.3rem;
+    min-width: 0;
     margin: 0;
     padding: 0;
     list-style: none;
 }
 
-.section-nav a {
+.page-nav-download {
+    flex: 0 0 auto;
+    margin-left: auto;
+    white-space: nowrap;
+}
+
+.page-nav-download-label-short {
+    display: none;
+}
+
+.page-nav a {
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
@@ -1600,15 +1792,29 @@ summary:focus-visible,
     transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
 }
 
-.section-nav a:hover {
+.page-nav a:hover {
     border-color: var(--panel-border);
     background: var(--accent-soft);
     color: var(--accent-strong);
 }
 
-/* Offset anchor targets so the sticky header does not cover section headings */
-main section[id] {
+.page-nav a[aria-current="page"] {
+    border-color: color-mix(in srgb, var(--accent) 42%, var(--panel-border));
+    background: var(--accent-soft);
+    color: var(--accent-strong);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.page-panel {
     scroll-margin-top: calc(var(--header-h, 76px) + 10px);
+}
+
+.page-panel.page-rendering {
+    position: absolute;
+    inset-inline: 0.75rem;
+    width: auto;
+    visibility: hidden;
+    pointer-events: none;
 }
 
 /* ===== Back-to-top floating button ===== */
@@ -1690,12 +1896,6 @@ button.back-to-top:hover:not(:disabled) {
 }
 
 @media (max-width: 900px) {
-    header.app-header {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0.75rem;
-    }
-
     .control-toolbar {
         grid-template-columns: 1fr;
     }
@@ -1730,11 +1930,11 @@ button.back-to-top:hover:not(:disabled) {
     }
 
     .top-nav {
-        width: 100%;
+        width: auto;
     }
 
     .top-nav .nav-list {
-        width: 100%;
+        width: auto;
         align-items: center;
         justify-content: flex-start;
     }
@@ -1775,15 +1975,77 @@ button.back-to-top:hover:not(:disabled) {
     .user-usage-actions button {
         flex: 1 1 160px;
     }
+
+    .controls-summary-text {
+        white-space: normal;
+    }
+
+    .app-header-main {
+        flex-wrap: nowrap;
+    }
+
+    .top-nav-label,
+    .page-nav-label {
+        display: none;
+    }
+
+    .top-nav a {
+        justify-content: center;
+        width: 32px;
+        padding-inline: 0;
+    }
+
+    .page-nav {
+        flex-wrap: nowrap;
+    }
+
+    .page-nav-list {
+        order: initial;
+        flex: 1 1 0;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        padding-bottom: 0.15rem;
+    }
+
+    .page-nav-download {
+        order: initial;
+    }
+
+    .page-nav-download-label {
+        display: none;
+    }
+
+    .page-nav-download-label-short {
+        display: inline;
+    }
+
+    .page-nav a {
+        white-space: nowrap;
+    }
+
+    .user-table-toolbar-meta {
+        width: 100%;
+        justify-content: space-between;
+    }
 }
 
 @media (max-width: 520px) {
-    header.app-header {
-        padding-top: 1rem;
+    .app-header-main {
+        padding-top: 0.75rem;
     }
 
     .logo-title h1 {
         font-size: 1.6rem;
+    }
+
+    .page-nav-download {
+        width: 34px;
+        padding-inline: 0;
+    }
+
+    .page-nav-download-label,
+    .page-nav-download-label-short {
+        display: none;
     }
 
     .quick-ranges {
@@ -1800,6 +2062,19 @@ button.back-to-top:hover:not(:disabled) {
         font-size: 0.85rem;
     }
 
+    .user-table-pagination {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .pagination-actions {
+        width: 100%;
+    }
+
+    .pagination-actions button {
+        flex: 1 1 0;
+    }
+
     .back-to-top {
         width: 44px;
         height: 44px;
@@ -1814,7 +2089,7 @@ button.back-to-top:hover:not(:disabled) {
     .app-header,
     .controls-panel,
     .app-footer,
-    .section-nav,
+    .page-nav,
     .back-to-top,
     .loading-overlay {
         display: none !important;
@@ -1838,7 +2113,7 @@ body.printing .app-footer {
     opacity: 0.3;
 }
 
-body.printing .section-nav,
+body.printing .page-nav,
 body.printing .back-to-top {
     display: none !important;
 }


### PR DESCRIPTION
## Summary

The dashboard's growing set of reports was difficult to navigate, and the Users table became cumbersome with larger datasets. This reorganizes the existing reports into page-style views while preserving loaded data and makes per-user analysis consistently accessible.

- Add Overview, Charts, AI Credits, Reference Tables, and Users views in a unified sticky header.
- Auto-collapse Load & Filter after successful imports and retain a compact filter summary.
- Add case-insensitive user search, sortable pagination with configurable page sizes, result counts, and cross-page CSV export.
- Preserve dashboard state across view changes and prevent navigation tabs from changing the scroll position.
- Keep Users available for empty and aggregate-only states while retaining responsive layouts and PDF behavior.

## Testing

- Loaded sample metric and aggregate-only data in the browser.
- Verified page switching, state preservation, filtering, search, sorting, pagination, CSV/PDF export, and responsive table scrolling.
- Ran `node --check script.js` and `git diff --check`.